### PR TITLE
Daguirre - Cleanup & Increasing Logging Test Coverage

### DIFF
--- a/StarWarsTracker.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/StarWarsTracker.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -45,7 +45,7 @@ namespace StarWarsTracker.Api.Middleware
             }
             catch (ValidationFailureException e)
             {
-                _logger.IncreaseLevel(_logConfigReader.GetCustomLogLevel(Section.ExceptionLogging, Key.ValidationFailureExceptionLogLevel) ?? Domain.Enums.LogLevel.None, 
+                _logger.IncreaseLevel(_logConfigReader.GetLogLevel(Section.ExceptionLogging, Key.ValidationFailureExceptionLogLevel) ?? Domain.Enums.LogLevel.None, 
                     "ValidationFailureException Caught", new { e.GetType().Name, e.ValidationFailureMessages, e.StackTrace });
 
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
@@ -54,7 +54,7 @@ namespace StarWarsTracker.Api.Middleware
             }
             catch (DoesNotExistException e)
             {
-                _logger.IncreaseLevel(_logConfigReader.GetCustomLogLevel(Section.ExceptionLogging, Key.DoesNotExistExceptionLogLevel) ?? Domain.Enums.LogLevel.None, 
+                _logger.IncreaseLevel(_logConfigReader.GetLogLevel(Section.ExceptionLogging, Key.DoesNotExistExceptionLogLevel) ?? Domain.Enums.LogLevel.None, 
                     "DoesNotExistException Caught", new { e.GetType().Name, e.NameOfObjectNotExisting, e.ValuesSearchedBy, e.StackTrace });
 
                 context.Response.StatusCode = StatusCodes.Status404NotFound;
@@ -63,7 +63,7 @@ namespace StarWarsTracker.Api.Middleware
             }
             catch (AlreadyExistsException e)
             {
-                _logger.IncreaseLevel(_logConfigReader.GetCustomLogLevel(Section.ExceptionLogging, Key.AlreadyExistsExceptionLogLevel) ?? Domain.Enums.LogLevel.None, 
+                _logger.IncreaseLevel(_logConfigReader.GetLogLevel(Section.ExceptionLogging, Key.AlreadyExistsExceptionLogLevel) ?? Domain.Enums.LogLevel.None, 
                     "AlreadyExistsException Caught", new { e.GetType().Name, e.NameOfObjectAlreadyExisting, e.Conflicts, e.StackTrace });
 
                 context.Response.StatusCode = StatusCodes.Status409Conflict;
@@ -72,7 +72,7 @@ namespace StarWarsTracker.Api.Middleware
             }
             catch (Exception e)
             {
-                _logger.IncreaseLevel(_logConfigReader.GetCustomLogLevel(Section.ExceptionLogging, Key.DefaultExceptionLogLevel) ?? Domain.Enums.LogLevel.None, 
+                _logger.IncreaseLevel(_logConfigReader.GetLogLevel(Section.ExceptionLogging, Key.DefaultExceptionLogLevel) ?? Domain.Enums.LogLevel.None, 
                     "Exception Caught", new { e.GetType().Name, e.Message, e.StackTrace });
                 
                 context.Response.StatusCode = StatusCodes.Status500InternalServerError;

--- a/StarWarsTracker.Api/Middleware/LoggingMiddleware.cs
+++ b/StarWarsTracker.Api/Middleware/LoggingMiddleware.cs
@@ -1,4 +1,5 @@
 ﻿using StarWarsTracker.Logging.Abstraction;
+using System.Diagnostics.CodeAnalysis;
 
 namespace StarWarsTracker.Api.Middleware
 {
@@ -8,6 +9,7 @@ namespace StarWarsTracker.Api.Middleware
     /// Additional Try/Catch is enabled in case of any exceptions making it past Global Exception Handler.
     /// LogMessage is saved using ILogWriter when the request is leaving the pipeline.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class LoggingMiddleware : IMiddleware
     {
         #region Private Members

--- a/StarWarsTracker.Application/Implementation/DatabaseLogger.cs
+++ b/StarWarsTracker.Application/Implementation/DatabaseLogger.cs
@@ -33,8 +33,8 @@ namespace StarWarsTracker.Application.Implementation
 
         public void Write(ILogMessage logMessage, string requestPath, string httpMethod)
         {
-            var minimumLoggingLevel = _logConfigReader.GetCustomLogLevel(Section.DatabaseLogSettings, Key.LogMessageLevelToWrite);
-            var contentLevel = _logConfigReader.GetCustomLogLevel(Section.DatabaseLogSettings, Key.LogContentLevelToWrite);
+            var minimumLoggingLevel = _logConfigReader.GetLogLevel(Section.DatabaseLogSettings, Key.LogMessageLevelToWrite);
+            var contentLevel = _logConfigReader.GetLogLevel(Section.DatabaseLogSettings, Key.LogContentLevelToWrite);
 
             if (minimumLoggingLevel == LogLevel.None)
             {

--- a/StarWarsTracker.Logging.Tests/AppSettingsConfigTests/LogConfigCategoryTests.cs
+++ b/StarWarsTracker.Logging.Tests/AppSettingsConfigTests/LogConfigCategoryTests.cs
@@ -1,0 +1,60 @@
+﻿using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Logging.AppSettingsConfig;
+
+namespace StarWarsTracker.Logging.Tests.AppSettingsConfigTests
+{
+    public class LogConfigCategoryTests
+    {
+        [Fact]
+        public void ToLogLevelCategories_Given_AllValuesAreValidLogLevels_ShouldReturn_DictionaryOfLogConfigSections()
+        {
+            var logConfigCategory = new LogConfigCategory()
+            {
+                { 
+                    "SectionOneKey", 
+                    new LogConfigSection()
+                    {
+                        { "Key1", LogLevel.Trace.ToString() },
+                        { "Key2", LogLevel.Debug.ToString() },
+                        { "Key3", LogLevel.Information.ToString() },
+                        { "Key4", LogLevel.Warning.ToString() },
+                        { "Key5", LogLevel.Error.ToString() },
+                        { "Key6", LogLevel.Critical.ToString() }
+                    } 
+                },
+                {
+                    "SectionTwoKey",
+                    new LogConfigSection()
+                    {
+                        { "Key1", LogLevel.Trace.ToString().ToUpper() },
+                        { "Key2", LogLevel.Debug.ToString().ToUpper() },
+                        { "Key3", LogLevel.Information.ToString().ToUpper() },
+                        { "Key4", LogLevel.Warning.ToString().ToUpper() },
+                        { "Key5", LogLevel.Error.ToString().ToUpper() },
+                        { "Key6", LogLevel.Critical.ToString().ToUpper() }
+                    }
+                },
+                {
+                    "SectionThreeKey",
+                    new LogConfigSection()
+                    {
+                        { "Key1", LogLevel.Trace.ToString().ToLower() },
+                        { "Key2", LogLevel.Debug.ToString().ToLower() },
+                        { "Key3", LogLevel.Information.ToString().ToLower() },
+                        { "Key4", LogLevel.Warning.ToString().ToLower() },
+                        { "Key5", LogLevel.Error.ToString().ToLower() },
+                        { "Key6", LogLevel.Critical.ToString().ToLower() }
+                    }
+                },
+            };
+
+            var expected = logConfigCategory
+                .ToDictionary(_ => _.Key, _ => _.Value
+                    .ToDictionary(_ => _.Key, _ => Enum.Parse<LogLevel>(_.Value, ignoreCase: true)));
+
+            var results = logConfigCategory.ToLogLevelCategories();
+
+            Assert.Equal(expected, results);
+        }
+    }
+}

--- a/StarWarsTracker.Logging.Tests/AppSettingsConfigTests/LogConfigSectionTests.cs
+++ b/StarWarsTracker.Logging.Tests/AppSettingsConfigTests/LogConfigSectionTests.cs
@@ -1,0 +1,48 @@
+﻿using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Logging.AppSettingsConfig;
+
+namespace StarWarsTracker.Logging.Tests.AppSettingsConfigTests
+{
+    public class LogConfigSectionTests
+    {
+        [Fact]
+        public void ToLogLevelDictionary_Given_AllValuesAreValidLogLevels_ShouldReturn_DictionaryOfLogLevels()
+        {
+            var logConfigSection = new LogConfigSection()
+            {
+                { "Key1", LogLevel.Trace.ToString() },
+                { "Key2", LogLevel.Debug.ToString() },
+                { "Key3", LogLevel.Information.ToString() },
+                { "Key4", LogLevel.Warning.ToString() },
+                { "Key5", LogLevel.Error.ToString() },
+                { "Key6", LogLevel.Critical.ToString() },
+                { "Key7", LogLevel.Trace.ToString().ToUpper() },
+                { "Key8", LogLevel.Trace.ToString().ToLower() },
+            };
+
+            var expected = logConfigSection.ToDictionary(_ => _.Key, _ => Enum.Parse<LogLevel>(_.Value, ignoreCase: true));
+
+            var results = logConfigSection.ToLogLevelDictionary();
+
+            Assert.Equal(expected, results);
+        }
+
+        [Fact]
+        public void ToLogLevelDictionary_Given_InvalidLogLevelValue_ShouldThrow_ApplicationException()
+        {
+            (string Key, string Value) badLogLevelConfig = ("Key", "Not a real LogLevel");
+
+            var logConfigSection = new LogConfigSection()
+            {
+                { "GoodKey", LogLevel.Trace.ToString() },
+                { badLogLevelConfig.Key, badLogLevelConfig.Value }
+            };
+
+            var exception = Record.Exception(() => logConfigSection.ToLogLevelDictionary());
+
+            Assert.IsType<ApplicationException>(exception);
+            Assert.Contains(badLogLevelConfig.Key, exception.Message);
+            Assert.Contains(badLogLevelConfig.Value, exception.Message);
+        }
+    }
+}

--- a/StarWarsTracker.Logging.Tests/AppSettingsConfigTests/LogConfigSettingsTests.cs
+++ b/StarWarsTracker.Logging.Tests/AppSettingsConfigTests/LogConfigSettingsTests.cs
@@ -1,0 +1,73 @@
+﻿using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Logging.AppSettingsConfig;
+
+namespace StarWarsTracker.Logging.Tests.AppSettingsConfigTests
+{
+    public class LogConfigSettingsTests
+    {
+        [Fact]
+        public void GetConfigs_Given_AllValuesAreValidLogLevels_ShouldReturn_DictionaryOfLogConfigCategories() 
+        {
+            var logConfigSettings = new LogConfigSettings()
+            {
+                {
+                    "CategoryOneKey",
+                    new LogConfigCategory()
+                    {
+                         {
+                            "SectionOneKey",
+                            new LogConfigSection()
+                            {
+                                { "Key1", LogLevel.Trace.ToString() },
+                                { "Key2", LogLevel.Debug.ToString() },
+                                { "Key3", LogLevel.Information.ToString() },
+                                { "Key4", LogLevel.Warning.ToString() },
+                                { "Key5", LogLevel.Error.ToString() },
+                                { "Key6", LogLevel.Critical.ToString() }
+                            }
+                         },
+                        {
+                            "SectionTwoKey",
+                            new LogConfigSection()
+                            {
+                                { "Key1", LogLevel.Trace.ToString().ToUpper() },
+                                { "Key2", LogLevel.Debug.ToString().ToUpper() },
+                                { "Key3", LogLevel.Information.ToString().ToUpper() },
+                                { "Key4", LogLevel.Warning.ToString().ToUpper() },
+                                { "Key5", LogLevel.Error.ToString().ToUpper() },
+                                { "Key6", LogLevel.Critical.ToString().ToUpper() }
+                            }
+                        }
+                    }
+                },
+                {
+                    "CategoryTwoKey",
+                    new LogConfigCategory()
+                    {
+                        {
+                            "SectionOneKey",
+                            new LogConfigSection()
+                            {
+                                { "Key1", LogLevel.Trace.ToString().ToLower() },
+                                { "Key2", LogLevel.Debug.ToString().ToLower() },
+                                { "Key3", LogLevel.Information.ToString().ToLower() },
+                                { "Key4", LogLevel.Warning.ToString().ToLower() },
+                                { "Key5", LogLevel.Error.ToString().ToLower() },
+                                { "Key6", LogLevel.Critical.ToString().ToLower() }
+                            }
+                         },
+                    }
+                }
+            };
+
+            var expected = logConfigSettings
+                .ToDictionary(_ => _.Key, _ => _.Value
+                    .ToDictionary(_ => _.Key, _ => _.Value
+                        .ToDictionary(_ => _.Key, _ => Enum.Parse<LogLevel>(_.Value, ignoreCase: true))));
+
+            var results = logConfigSettings.GetConfigs();
+
+            Assert.Equal(expected, results);
+        }
+    }
+}

--- a/StarWarsTracker.Logging.Tests/ImplementationTests/ClassLoggerFactoryTests.cs
+++ b/StarWarsTracker.Logging.Tests/ImplementationTests/ClassLoggerFactoryTests.cs
@@ -1,0 +1,60 @@
+﻿using Moq;
+using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Domain.Models;
+using StarWarsTracker.Logging.Abstraction;
+using StarWarsTracker.Logging.Implementation;
+
+namespace StarWarsTracker.Logging.Tests.ImplementationTests
+{
+    public class ClassLoggerFactoryTests
+    {
+        #region Private Members
+
+        private readonly ClassLoggerFactory _factory;
+
+        private readonly Mock<ILogMessage> _mockLogMessage = new();
+
+        #endregion
+
+        #region Constructor
+
+        public ClassLoggerFactoryTests()
+        {
+            _factory = new(_mockLogMessage.Object, new Mock<ILogConfigReader>().Object);
+        }
+
+        #endregion
+
+        #region GetLoggerFor Test
+
+        [Fact]
+        public void GetLoggerFor_Given_Object_ShouldReturn_ClassLogger_ForThatObject()
+        {
+            var obj = new Event();
+
+            var description = "Description";
+            var extra = "Extra";
+            var methodCalling = "MethodCalling";
+            var logLevel = LogLevel.Critical;
+
+            var result = _factory.GetLoggerFor(obj);
+
+            Assert.NotNull(result);
+
+            result.IncreaseLevel(logLevel, description, extra, methodCalling);
+
+            _mockLogMessage.Verify(_ => 
+                //_.IncreaseLevel(It.IsAny<LogContent>())
+                _.IncreaseLevel(It.Is<LogContent>(_ => 
+                       _.LogLevel == logLevel 
+                    && _.Description == description
+                    && _.Extra as string == extra
+                    && _.MethodCalling == methodCalling
+                    && _.ClassName == obj.GetType().Name
+                    && _.NameSpace == obj.GetType().Namespace
+                )), Times.Once());
+        }
+        
+        #endregion
+    }
+}

--- a/StarWarsTracker.Logging.Tests/ImplementationTests/ClassLoggerTests.cs
+++ b/StarWarsTracker.Logging.Tests/ImplementationTests/ClassLoggerTests.cs
@@ -1,0 +1,568 @@
+﻿using Moq;
+using StarWarsTracker.Domain.Constants.LogConfigs;
+using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Logging.Abstraction;
+using StarWarsTracker.Logging.Implementation;
+
+namespace StarWarsTracker.Logging.Tests.ImplementationTests
+{
+    public class ClassLoggerTests
+    {
+        #region Private Members
+
+        private readonly Mock<ILogMessage> _mockLogMessage = new();
+
+        private readonly Mock<ILogConfigReader> _mockLogConfigReader = new();
+
+        private readonly ClassLogger _classLogger;
+
+        #endregion
+
+        #region Private Constants for Expected Values
+
+        private const string _className = "ClassName";
+
+        private const string _nameSpaceName = "NameSpaceName";
+
+        private const string _description = "Description";
+
+        private const string _extra = "Extra";
+
+        private const string _methodCalling = "MethodCalling";
+
+        #endregion
+
+        #region Constructor
+
+        public ClassLoggerTests()
+        {
+            _classLogger = new(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+        }
+
+        #endregion
+
+        #region Reuseable Test Case Parameters
+
+        public static IEnumerable<object[]> AllLogLevels = new[]
+        {
+            new object []{ LogLevel.Trace },
+            new object []{ LogLevel.Debug },
+            new object []{ LogLevel.Information },
+            new object []{ LogLevel.Warning },
+            new object []{ LogLevel.Error },
+            new object []{ LogLevel.Critical },
+            new object []{ LogLevel.None }
+        };
+
+        #endregion
+
+        #region AddTrace Tests
+
+        [Fact]
+        public void AddTrace_Given_NoOverrides_ShouldAdd_LogContentAsTrace()
+        {
+            var expectedLogLevel = LogLevel.Trace;
+
+            _classLogger.AddTrace(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddTrace_Given_OnlyNamespaceOverride_ShouldAdd_LogContent_WithNamespaceOverride(LogLevel expectedLogLevel)
+        {
+            var nameSpaceOverrides = GetNamespaceOverrides(LogLevel.Trace, expectedLogLevel);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigCategory(Category.OverrideLogLevelByNameSpace))
+                                .Returns(() => nameSpaceOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddTrace(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddTrace_Given_OnlyClassOverride_ShouldAdd_LogContent_WithClassOverride(LogLevel expectedLogLevel)
+        {
+            var classNameOverrides = GetClassOverrides(LogLevel.Trace, expectedLogLevel);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigSection(Category.OverrideLogLevelByClassName, _className))
+                                .Returns(() => classNameOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddTrace(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddTrace_Given_NamespaceAndClassOverride_ShouldAdd_LogContent_WithClassOverride(LogLevel expectedLogLevel)
+        {
+            var classNameOverrides = GetClassOverrides(LogLevel.Trace, expectedLogLevel);
+            var namespaceOverrides = GetNamespaceOverrides(LogLevel.Trace, LogLevel.None);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigSection(Category.OverrideLogLevelByClassName, _className))
+                                .Returns(() => classNameOverrides);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigCategory(Category.OverrideLogLevelByNameSpace))
+                                .Returns(() => namespaceOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddTrace(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        #endregion
+
+        #region AddDebug Tests
+
+        [Fact]
+        public void AddDebug_Given_NoOverrides_ShouldAdd_LogContentAsDebug()
+        {
+            var expectedLogLevel = LogLevel.Debug;
+
+            _classLogger.AddDebug(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddDebug_Given_OnlyNamespaceOverride_ShouldAdd_LogContent_WithNamespaceOverride(LogLevel expectedLogLevel)
+        {
+            var nameSpaceOverrides = GetNamespaceOverrides(LogLevel.Debug, expectedLogLevel);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigCategory(Category.OverrideLogLevelByNameSpace))
+                                .Returns(() => nameSpaceOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddDebug(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddDebug_Given_OnlyClassOverride_ShouldAdd_LogContent_WithClassOverride(LogLevel expectedLogLevel)
+        {
+            var classNameOverrides = GetClassOverrides(LogLevel.Debug, expectedLogLevel);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigSection(Category.OverrideLogLevelByClassName, _className))
+                                .Returns(() => classNameOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddDebug(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddDebug_Given_NamespaceAndClassOverride_ShouldAdd_LogContent_WithClassOverride(LogLevel expectedLogLevel)
+        {
+            var classNameOverrides = GetClassOverrides(LogLevel.Debug, expectedLogLevel);
+            var namespaceOverrides = GetNamespaceOverrides(LogLevel.Debug, LogLevel.None);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigSection(Category.OverrideLogLevelByClassName, _className))
+                                .Returns(() => classNameOverrides);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigCategory(Category.OverrideLogLevelByNameSpace))
+                                .Returns(() => namespaceOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddDebug(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        #endregion
+
+        #region AddInformation Tests
+
+        [Fact]
+        public void AddInfo_Given_NoOverrides_ShouldAdd_LogContentAsInformation()
+        {
+            var expectedLogLevel = LogLevel.Information;
+
+            _classLogger.AddInfo(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddInfo_Given_OnlyNamespaceOverride_ShouldAdd_LogContent_WithNamespaceOverride(LogLevel expectedLogLevel)
+        {
+            var nameSpaceOverrides = GetNamespaceOverrides(LogLevel.Information, expectedLogLevel);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigCategory(Category.OverrideLogLevelByNameSpace))
+                                .Returns(() => nameSpaceOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddInfo(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddInfo_Given_OnlyClassOverride_ShouldAdd_LogContent_WithClassOverride(LogLevel expectedLogLevel)
+        {
+            var classNameOverrides = GetClassOverrides(LogLevel.Information, expectedLogLevel);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigSection(Category.OverrideLogLevelByClassName, _className))
+                                .Returns(() => classNameOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddInfo(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddInfo_Given_NamespaceAndClassOverride_ShouldAdd_LogContent_WithClassOverride(LogLevel expectedLogLevel)
+        {
+            var classNameOverrides = GetClassOverrides(LogLevel.Information, expectedLogLevel);
+            var namespaceOverrides = GetNamespaceOverrides(LogLevel.Information, LogLevel.None);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigSection(Category.OverrideLogLevelByClassName, _className))
+                                .Returns(() => classNameOverrides);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigCategory(Category.OverrideLogLevelByNameSpace))
+                                .Returns(() => namespaceOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddInfo(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        #endregion
+
+        #region AddWarning Tests
+
+        [Fact]
+        public void AddWarning_Given_NoOverrides_ShouldAdd_LogContentAsWarning()
+        {
+            var expectedLogLevel = LogLevel.Warning;
+
+            _classLogger.AddWarning(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddWarning_Given_OnlyNamespaceOverride_ShouldAdd_LogContent_WithNamespaceOverride(LogLevel expectedLogLevel)
+        {
+            var nameSpaceOverrides = GetNamespaceOverrides(LogLevel.Warning, expectedLogLevel);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigCategory(Category.OverrideLogLevelByNameSpace))
+                                .Returns(() => nameSpaceOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddWarning(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddWarning_Given_OnlyClassOverride_ShouldAdd_LogContent_WithClassOverride(LogLevel expectedLogLevel)
+        {
+            var classNameOverrides = GetClassOverrides(LogLevel.Warning, expectedLogLevel);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigSection(Category.OverrideLogLevelByClassName, _className))
+                                .Returns(() => classNameOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddWarning(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddWarning_Given_NamespaceAndClassOverride_ShouldAdd_LogContent_WithClassOverride(LogLevel expectedLogLevel)
+        {
+            var classNameOverrides = GetClassOverrides(LogLevel.Warning, expectedLogLevel);
+            var namespaceOverrides = GetNamespaceOverrides(LogLevel.Warning, LogLevel.None);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigSection(Category.OverrideLogLevelByClassName, _className))
+                                .Returns(() => classNameOverrides);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigCategory(Category.OverrideLogLevelByNameSpace))
+                                .Returns(() => namespaceOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddWarning(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        #endregion
+
+        #region AddError Tests
+
+        [Fact]
+        public void AddError_Given_NoOverrides_ShouldAdd_LogContentAsError()
+        {
+            var expectedLogLevel = LogLevel.Error;
+
+            _classLogger.AddError(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddError_Given_OnlyNamespaceOverride_ShouldAdd_LogContent_WithNamespaceOverride(LogLevel expectedLogLevel)
+        {
+            var nameSpaceOverrides = GetNamespaceOverrides(LogLevel.Error, expectedLogLevel);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigCategory(Category.OverrideLogLevelByNameSpace))
+                                .Returns(() => nameSpaceOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddError(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddError_Given_OnlyClassOverride_ShouldAdd_LogContent_WithClassOverride(LogLevel expectedLogLevel)
+        {
+            var classNameOverrides = GetClassOverrides(LogLevel.Error, expectedLogLevel);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigSection(Category.OverrideLogLevelByClassName, _className))
+                                .Returns(() => classNameOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddError(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddError_Given_NamespaceAndClassOverride_ShouldAdd_LogContent_WithClassOverride(LogLevel expectedLogLevel)
+        {
+            var classNameOverrides = GetClassOverrides(LogLevel.Error, expectedLogLevel);
+            var namespaceOverrides = GetNamespaceOverrides(LogLevel.Error, LogLevel.None);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigSection(Category.OverrideLogLevelByClassName, _className))
+                                .Returns(() => classNameOverrides);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigCategory(Category.OverrideLogLevelByNameSpace))
+                                .Returns(() => namespaceOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddError(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        #endregion
+
+        #region AddCritical Tests
+
+        [Fact]
+        public void AddCritical_Given_NoOverrides_ShouldAdd_LogContentAsCritical()
+        {
+            var expectedLogLevel = LogLevel.Critical;
+
+            _classLogger.AddCritical(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddCritical_Given_OnlyNamespaceOverride_ShouldAdd_LogContent_WithNamespaceOverride(LogLevel expectedLogLevel)
+        {
+            var nameSpaceOverrides = GetNamespaceOverrides(LogLevel.Critical, expectedLogLevel);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigCategory(Category.OverrideLogLevelByNameSpace))
+                                .Returns(() => nameSpaceOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddCritical(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddCritical_Given_OnlyClassOverride_ShouldAdd_LogContent_WithClassOverride(LogLevel expectedLogLevel)
+        {
+            var classNameOverrides = GetClassOverrides(LogLevel.Critical, expectedLogLevel);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigSection(Category.OverrideLogLevelByClassName, _className))
+                                .Returns(() => classNameOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddCritical(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddCritical_Given_NamespaceAndClassOverride_ShouldAdd_LogContent_WithClassOverride(LogLevel expectedLogLevel)
+        {
+            var classNameOverrides = GetClassOverrides(LogLevel.Critical, expectedLogLevel);
+            var namespaceOverrides = GetNamespaceOverrides(LogLevel.Critical, LogLevel.None);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigSection(Category.OverrideLogLevelByClassName, _className))
+                                .Returns(() => classNameOverrides);
+
+            _mockLogConfigReader.Setup(_ => _.GetConfigCategory(Category.OverrideLogLevelByNameSpace))
+                                .Returns(() => namespaceOverrides);
+
+            var classLogger = new ClassLogger(_className, _nameSpaceName, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddCritical(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        #endregion
+
+        #region AddConfiguredLogLevel Tests
+
+        [Fact]
+        public void AddConfiguredLogLevel_Given_LogLevelNotConfigured_ShouldAdd_LogContentWithLogLevel_None()
+        {
+            var expectedLogLevel = LogLevel.None;
+
+            _classLogger.AddConfiguredLogLevel("FakeConfigSection", "FakeConfigKey", _description, _extra, "FakeCategoryKey", _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void AddConfiguredLogLevel_Given_LogLevelIsConfigured_ShouldAdd_LogContentWithLogLevel_None(LogLevel expectedLogLevel)
+        {
+            var configCategoryKey = "CategoryKey";
+            var configSectionKey = "SectionKey";
+            var configKey = "ConfigKey";
+
+            _mockLogConfigReader.Setup(_ => _.GetLogLevel(configSectionKey, configKey, configCategoryKey)).Returns(() => expectedLogLevel);
+
+            _classLogger.AddConfiguredLogLevel(configSectionKey, configKey, _description, _extra, configCategoryKey, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel);
+        }
+
+        #endregion
+
+        #region IncreaseLogLevel Tests
+
+        [Theory]
+        [MemberData(nameof(AllLogLevels))]
+        public void IncreaseLogLevel_Given_LogLevelNotNone_ShouldIncrease_LogMessageLogLevel_ToLogLevelProvided(LogLevel expectedLogLevel)
+        {
+            _classLogger.IncreaseLevel(expectedLogLevel, _description, _extra, _methodCalling);
+
+            _mockLogMessage.Verify(_ => 
+                _.IncreaseLevel(It.Is<LogContent>(_ =>
+                       _.LogLevel == expectedLogLevel
+                    && _.ClassName == _className
+                    && _.NameSpace == _nameSpaceName
+                    && _.MethodCalling == _methodCalling
+                    && _.Description == _description
+                    && _.Extra as string == _extra
+                    )), Times.Once());
+        }
+
+        #endregion
+
+        #region Edge Case Tests
+
+        [Fact]
+        public void ClassLogger_Given_NamespaceIsNull_ShouldAdd_ContentWithNamespace_Unknown()
+        {
+            var expectedNamespace = "Unknown";
+            var expectedLogLevel = LogLevel.Trace;
+
+            var classLogger = new ClassLogger(_className, namespaceName: null, _mockLogMessage.Object, _mockLogConfigReader.Object);
+
+            classLogger.AddTrace(_description, _extra, _methodCalling);
+
+            AssertAddContentCalledWithLogLevel(expectedLogLevel, _className, expectedNamespace, _methodCalling, _description, _extra);
+        }
+
+        #endregion
+
+        #region Private Helper Methods
+
+        /// <summary>
+        /// Helper for getting a Dictionary that has an override for a specific key/value.        
+        /// <param name="key"></param>
+        /// <param name="overrideValue"></param>
+        /// <returns></returns>
+        private Dictionary<string, LogLevel> GetClassOverrides(LogLevel key, LogLevel overrideValue) =>
+            new() { { key.ToString(), overrideValue } };
+
+        /// <summary>
+        /// Helper for getting a Dictionary for nameSpace overrides that has an override for a specific key/value.
+        /// The namespace parameter defaults to constant for namespace.
+        /// </summary>
+        private Dictionary<string, Dictionary<string, LogLevel>> GetNamespaceOverrides(
+            LogLevel key, LogLevel overrideValue, string nameSpace = _nameSpaceName) =>
+                new()
+                {
+                    {   nameSpace,
+                        new()
+                        {
+                            { key.ToString(), overrideValue }
+                        }
+                    },
+                };
+
+        /// <summary>
+        /// Helper for asserting that content is added to LogMessage with expected LogLevel. 
+        /// Other values default to constants for className, namespace, methodCalling, description, extra.
+        /// expectedNumberOfTimesCalled defaults to 1.
+        /// </summary>
+        private void AssertAddContentCalledWithLogLevel(LogLevel expectedLogLevel,
+            string className = _className, string nameSpace = _nameSpaceName, string methodCalling = _methodCalling,
+            string description = _description, string extra = _extra, int expectedTimesCalled = 1) =>
+                _mockLogMessage.Verify(_ =>
+                   _.AddContent(It.Is<LogContent>(c =>
+                          c.LogLevel == expectedLogLevel
+                       && c.ClassName == className
+                       && c.NameSpace == nameSpace
+                       && c.MethodCalling == methodCalling
+                       && c.Description == description
+                       && c.Extra as string == extra
+                       )), Times.Exactly(expectedTimesCalled));
+    }
+    
+    #endregion
+}

--- a/StarWarsTracker.Logging.Tests/ImplementationTests/LogConfigReaderTests.cs
+++ b/StarWarsTracker.Logging.Tests/ImplementationTests/LogConfigReaderTests.cs
@@ -1,0 +1,286 @@
+﻿using Moq;
+using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Logging.Abstraction;
+using StarWarsTracker.Logging.Implementation;
+
+namespace StarWarsTracker.Logging.Tests.ImplementationTests
+{
+    public class LogConfigReaderTests
+    {
+        #region Private Members
+
+        private readonly Mock<ILogConfig> _mockLogConfig = new();
+
+        private readonly Dictionary<string, Dictionary<string, Dictionary<string, LogLevel>>> _defaultConfigs = new();
+
+        private readonly Dictionary<string, Dictionary<string, Dictionary<string, LogLevel>>> _endpointOverrideConfigs = new();
+
+        private const string _endpointOverridesKey = "EndpointOverridesKey";
+
+        private readonly LogConfigReader _logConfigReader;
+
+        #endregion
+
+        #region Constructor
+
+        public LogConfigReaderTests()
+        {
+            _mockLogConfig.Setup(_ => _.GetDefaultConfigs()).Returns(_defaultConfigs);
+            _mockLogConfig.Setup(_ => _.GetEndpointConfigs(_endpointOverridesKey)).Returns(_endpointOverrideConfigs);
+
+            _logConfigReader = new(_mockLogConfig.Object);
+        }
+
+        #endregion
+
+        #region GetActiveConfigs Test
+
+        [Fact]
+        public void GetActiveConfigs_Given_EndpointConfigsNotSet_ShouldReturn_DefaultConfigs()
+        {
+            var expected = _mockLogConfig.Object.GetDefaultConfigs();
+
+            var result = _logConfigReader.GetActiveConfigs();
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void GetActiveConfigs_Given_EndpointConfigsSet_ShouldReturn_EndpointOverrides()
+        {
+            var category = "CategoryKey";
+            var section = "SectionKey";
+            var key = "Key";
+            var defaultLogLevel = LogLevel.Trace;
+            var endpointOverrideLogLevel = LogLevel.Critical;
+
+            _defaultConfigs.Add(
+               category,
+               new()
+               {
+                    {
+                        section,
+                        new()
+                        {
+                            { key, defaultLogLevel },
+                        }
+                    }
+               });
+
+            _endpointOverrideConfigs.Add(
+                category,
+                new()
+                {
+                    {
+                        section,
+                        new()
+                        {
+                            { key, endpointOverrideLogLevel },
+                        }
+                    }
+                });
+
+            _logConfigReader.TrySetEndpointConfigs(_endpointOverridesKey);
+
+            var expected = _endpointOverrideConfigs;
+
+            var configs = _logConfigReader.GetActiveConfigs();
+
+            Assert.Equal(expected, configs);
+        }
+
+        #endregion
+
+        #region GetConfigCategory Tests
+
+        [Fact]
+        public void GetConfigCategory_Given_NoCategoryFound_ShouldReturn_Null()
+        {
+            var categoryKey = "FakeKey";
+
+            var result =_logConfigReader.GetConfigCategory(categoryKey);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetConfigCategory_Given_ConfigCategoryFound_ShouldReturn_Category()
+        {
+            var categoryKey = "categoryKey";
+
+            var expectedCategory = new Dictionary<string, Dictionary<string, LogLevel>>();
+
+            _defaultConfigs.Add(categoryKey, expectedCategory);
+
+            var result = _logConfigReader.GetConfigCategory(categoryKey);
+
+            Assert.Equal(expectedCategory, result);
+        }
+
+        #endregion
+
+        #region GetConfigSection Tests
+
+        [Fact]
+        public void GetConfigSection_Given_NoConfigCategoryFound_ShouldReturn_Null()
+        {
+            var categoryKey = "FakeKey";
+            var sectionKey = "FakeSectionKey";
+
+            var result = _logConfigReader.GetConfigSection(categoryKey, sectionKey);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetConfigSection_Given_NoConfigSectionFound_ShouldReturn_Null()
+        {
+            var categoryKey = "ExistingCategoryKey";
+            var sectionKey = "FakeSectionKey";
+
+            _defaultConfigs.Add(categoryKey, new());
+
+            var result = _logConfigReader.GetConfigSection(categoryKey, sectionKey);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetConfigSection_Given_ConfigSectionFound_ShouldReturn_ConfigSection()
+        {
+            var categoryKey = "ExistingCategoryKey";
+            var sectionKey = "ExistingSectionKey";
+
+            var expectedSection = new Dictionary<string, LogLevel>();
+
+            _defaultConfigs.Add(
+                categoryKey, 
+                new()
+                {
+                    { sectionKey, expectedSection }
+                });
+
+            var result = _logConfigReader.GetConfigSection(categoryKey, sectionKey);
+
+            Assert.Equal(expectedSection, result);
+        }
+
+        #endregion
+
+        #region GetLogLevel Tests
+
+        [Fact]
+        public void GetLogLevel_Given_NoConfigCategoryFound_ShouldReturn_Null()
+        {
+            var result = _logConfigReader.GetLogLevel("FakeSection", "FakeKey", "FakeCategory");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetLogLevel_Given_NoConfigSectionFound_ShouldReturn_Null()
+        {
+            var categoryKey = "ExistingCategoryKey";
+
+            _defaultConfigs.Add(categoryKey, new());
+
+            var result = _logConfigReader.GetLogLevel("FakeSection", "FakeKey", categoryKey);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetLogLevel_Given_NoKeyFound_ShouldRetun_Null()
+        {
+            var categoryKey = "ExistingCategoryKey";
+            var sectionKey = "ExistingSectionKey";
+
+            _defaultConfigs.Add(categoryKey, new() { { sectionKey, new() } });
+
+            var result = _logConfigReader.GetLogLevel(sectionKey, "FakeKey", categoryKey);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetLogLevel_Given_KeyFound_ShouldReturn_Value()
+        {
+            var categoryKey = "ExistingCategoryKey";
+            var sectionKey = "ExistingSectionKey";
+            var key = "ExistingKey";
+            var expectedValue = LogLevel.Critical;
+
+            _defaultConfigs.Add(categoryKey, new() { { sectionKey, new() { { key, expectedValue } } } });
+
+            var result = _logConfigReader.GetLogLevel(sectionKey, key, categoryKey);
+
+            Assert.Equal(expectedValue, result);
+        }
+
+        #endregion
+
+        #region TrySetEndpointConfigs Tests
+
+        [Fact]
+        public void TrySetEndpointConfigs_Given_NoEndpointOverridesFound_ShouldRetun_False()
+        {
+            var result = _logConfigReader.TrySetEndpointConfigs("FakeEndpointRoute");
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void TrySetEndpointConfigs_Given_DefaultConfigNotContainingCategory_Should_AddCategory()
+        {
+            var categoryKey = "CategoryKey";
+            var expectedCategory = new Dictionary<string, Dictionary<string, LogLevel>>();
+
+            _endpointOverrideConfigs.Add(categoryKey, expectedCategory);
+
+            var overrideApplied = _logConfigReader.TrySetEndpointConfigs(_endpointOverridesKey);
+
+            var result = _logConfigReader.GetConfigCategory(categoryKey);
+
+            Assert.True(overrideApplied);
+            Assert.Equal(expectedCategory, result);
+        }
+
+        [Fact]
+        public void TrySetEndpointConfigs_Given_DefaultConfigNotContainingSection_Should_AddSection()
+        {
+            var categoryKey = "CategoryKey";
+            var sectionKey = "SectionKey";
+            var expectedSection = new Dictionary<string, LogLevel>();
+
+            _defaultConfigs.Add(categoryKey, new());
+            _endpointOverrideConfigs.Add(categoryKey, new() { { sectionKey, expectedSection } });
+
+            var overrideApplied = _logConfigReader.TrySetEndpointConfigs(_endpointOverridesKey);
+
+            var result = _logConfigReader.GetConfigSection(categoryKey, sectionKey);
+
+            Assert.True(overrideApplied);
+            Assert.Equal(expectedSection, result);
+        }
+
+        [Fact]
+        public void TrySetEndpointConfigs_Given_DefaultConfigNotContainingKey_Should_AddKeyValue()
+        {
+            var categoryKey = "CategoryKey";
+            var sectionKey = "SectionKey";
+            (string Key,  LogLevel Value) expected = ("Key", LogLevel.Critical);
+
+            _defaultConfigs.Add(categoryKey, new() { {  sectionKey, new() } });
+            _endpointOverrideConfigs.Add(categoryKey, new() { { sectionKey, new() { { expected.Key, expected.Value } } } });
+
+            var overrideApplied = _logConfigReader.TrySetEndpointConfigs(_endpointOverridesKey);
+
+            var result = _logConfigReader.GetLogLevel(sectionKey, expected.Key, categoryKey);
+
+            Assert.True(overrideApplied);
+            Assert.Equal(expected.Value, result);
+        }
+
+        #endregion
+    }
+}

--- a/StarWarsTracker.Logging.Tests/ImplementationTests/LogConfigTests.cs
+++ b/StarWarsTracker.Logging.Tests/ImplementationTests/LogConfigTests.cs
@@ -1,0 +1,151 @@
+﻿using StarWarsTracker.Domain.Constants.LogConfigs;
+using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Logging.AppSettingsConfig;
+using StarWarsTracker.Logging.Implementation;
+
+namespace StarWarsTracker.Logging.Tests.ImplementationTests
+{
+    public class LogConfigTests
+    {
+        #region Private Members
+
+        private readonly Dictionary<string, LogConfigSettings> _configs;
+
+        private const string _endpointOverrideKey = "ExampleEndpoint";
+
+        private const string _defaultConfigsKey = Category.Default;
+
+        private readonly LogConfig _logConfig;
+
+        #endregion
+
+        #region Constructor 
+
+        public LogConfigTests()
+        {            
+            _configs = new()
+            {
+                {
+                    _defaultConfigsKey,
+                    new()
+                    {
+                        {
+                            "CategoryOne",
+                            new()
+                            {
+                                {
+                                    "SectionOne",
+                                    new()
+                                    {
+                                        { "Key1", LogLevel.Trace.ToString() },
+                                        { "Key2", LogLevel.Debug.ToString() },
+                                        { "Key3", LogLevel.Information.ToString() },
+                                        { "Key4", LogLevel.Warning.ToString() },
+                                        { "Key5", LogLevel.Error.ToString() },
+                                        { "Key6", LogLevel.Critical.ToString() },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    _endpointOverrideKey,
+                    new()
+                    {
+                        {
+                            "CategoryOne",
+                            new()
+                            {
+                                {
+                                    "SectionOne",
+                                    new()
+                                    {
+                                        { "Key1", LogLevel.None.ToString() },
+                                        { "Key2", LogLevel.None.ToString() },
+                                        { "Key3", LogLevel.None.ToString() },
+                                        { "Key4", LogLevel.None.ToString() },
+                                        { "Key5", LogLevel.None.ToString() },
+                                        { "Key6", LogLevel.None.ToString() },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            _logConfig = new(_configs);
+
+        }
+
+        #endregion
+
+        #region Constructor Test (KeyNotFoundException When Default Configs Missing)
+        
+        [Fact]
+        public void LogConfig_Given_DefaultConfigsNotExisting_ShouldThrow_KeyNotFoundException()
+        {
+            _configs.Remove(_defaultConfigsKey);
+
+            var exception = Record.Exception(() => new LogConfig(_configs));
+
+            Assert.IsType<KeyNotFoundException>(exception);
+        }
+
+        #endregion
+
+        #region GetDefaultConfigs Test
+
+        [Fact]
+        public void GetDefaultConfigs_Given_DefaultConfigsExist_ShouldReturn_DefaultConfigs()
+        {
+            var expected = _configs[_defaultConfigsKey]
+                .ToDictionary(_ => _.Key, _ => _.Value
+                    .ToDictionary(_ => _.Key, _ => _.Value
+                        .ToDictionary(_ => _.Key, _ => Enum.Parse<LogLevel>(_.Value))));
+
+            var results = _logConfig.GetDefaultConfigs();
+
+            Assert.Equal(expected, results);
+        }
+
+        #endregion
+
+        #region GetEndpointConfigs Tests
+
+        [Fact]
+        public void GetEndpointConfigs_Given_EndpointConfigsExist_ShouldReturn_EndpointConfigs()
+        {
+            var expected = _configs[_endpointOverrideKey]
+                .ToDictionary(_ => _.Key, _ => _.Value
+                    .ToDictionary(_ => _.Key, _ => _.Value
+                        .ToDictionary(_ => _.Key, _ => Enum.Parse<LogLevel>(_.Value))));
+
+            var results = _logConfig.GetEndpointConfigs(_endpointOverrideKey);
+
+            Assert.Equal(expected, results);
+        }
+
+        [Fact]
+        public void GetEndpointConfigs_Given_EndpointConfigsNotExisting_ShouldReturn_Null()
+        {
+            var results = _logConfig.GetEndpointConfigs("FakeKey");
+
+            Assert.Null(results);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData(null)]
+        public void GetEndpointConfigs_Given_NullEmptyOrWhitespace_ShouldReturn_Null(string input)
+        {
+            var results = _logConfig.GetEndpointConfigs(input);
+
+            Assert.Null(results);
+        }
+
+        #endregion
+    }
+}

--- a/StarWarsTracker.Logging.Tests/ImplementationTests/LogMessageTests.cs
+++ b/StarWarsTracker.Logging.Tests/ImplementationTests/LogMessageTests.cs
@@ -13,6 +13,40 @@ namespace StarWarsTracker.Logging.Tests.ImplementationTests
 
         #endregion
 
+        #region AddContent Tests
+
+        [Fact]
+        public void AddContent_Given_LogContentLogLevelIsNone_Should_NotAddContent()
+        {
+            _content.LogLevel = LogLevel.None;
+
+            _logMessage.AddContent(_content);
+
+            var contents = _logMessage.GetAllContent();
+
+            Assert.Empty(contents);
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Trace)]
+        [InlineData(LogLevel.Debug)]
+        [InlineData(LogLevel.Information)]
+        [InlineData(LogLevel.Warning)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Critical)]
+        public void AddContent_Given_LogContentLogLevelNotNone_Should_AddLogContent(LogLevel logLevel)
+        {
+            _content.LogLevel = logLevel;
+
+            _logMessage.AddContent(_content);
+
+            var contents = _logMessage.GetAllContent();
+
+            Assert.Equal(_content, contents.Single());
+        }
+
+        #endregion
+
         #region GetMessageLogLevel Tests
 
         [Fact]
@@ -104,5 +138,39 @@ namespace StarWarsTracker.Logging.Tests.ImplementationTests
 
         #endregion
 
+        #region GetContent Tests
+
+        [Fact]
+        public void GetContent_Given_LogLevelNone_ShouldReturn_EmptyCollection()
+        {
+            _logMessage.AddContent(_content);
+
+            var results = _logMessage.GetContent(LogLevel.None);
+
+            Assert.Empty(results);
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Trace)]
+        [InlineData(LogLevel.Debug)]
+        [InlineData(LogLevel.Information)]
+        [InlineData(LogLevel.Warning)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Critical)]
+        public void GetContent_Given_LogLevel_ShouldReturn_LogContentAboveOrEqualToLogLevel(LogLevel logLevel)
+        {
+            _logMessage.AddContent(new(LogLevel.Trace, "TraceClass", "TraceNamespace", "TraceMethod", "TraceDescription", "TraceExtra", 1.23));
+            _logMessage.AddContent(new(LogLevel.Debug, "DebugClass", "DebugNamespace", "DebugMethod", "DebugDescription", "DebugExtra", 2.34));
+            _logMessage.AddContent(new(LogLevel.Information, "InformationClass", "InformationNamespace", "InformationMethod", "InformationDescription", "InformationExtra", 3.45));
+            _logMessage.AddContent(new(LogLevel.Warning, "WarningClass", "WarningNamespace", "WarningMethod", "WarningDescription", "WarningExtra", 4.56));
+            _logMessage.AddContent(new(LogLevel.Error, "ErrorClass", "ErrorNamespace", "ErrorMethod", "ErrorDescription", "ErrorExtra", 5.67));
+            _logMessage.AddContent(new(LogLevel.Critical, "CriticalClass", "CriticalNamespace", "CriticalMethod", "CriticalDescription", "CriticalExtra", 6.78));
+
+            var results = _logMessage.GetContent(logLevel);
+
+            Assert.True(results.All(_ => _.LogLevel >= logLevel));
+        }
+
+        #endregion
     }
 }

--- a/StarWarsTracker.Logging.Tests/StarWarsTracker.Logging.Tests.csproj
+++ b/StarWarsTracker.Logging.Tests/StarWarsTracker.Logging.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/StarWarsTracker.Logging/Abstraction/IClassLogger.cs
+++ b/StarWarsTracker.Logging/Abstraction/IClassLogger.cs
@@ -1,4 +1,5 @@
-﻿using StarWarsTracker.Domain.Enums;
+﻿using StarWarsTracker.Domain.Constants.LogConfigs;
+using StarWarsTracker.Domain.Enums;
 using System.Runtime.CompilerServices;
 
 namespace StarWarsTracker.Logging.Abstraction
@@ -83,7 +84,8 @@ namespace StarWarsTracker.Logging.Abstraction
 
         /// <summary>
         /// Add the description and optional extra object as LogContent to the LogMessage.
-        /// The LogContent will be a loglevel that is configured under CustomLogLevels with the logConfigSection and logConfigKey provided.
+        /// The LogContent will be a loglevel that is configured under the logConfigSection and logConfigKey provided.
+        /// The ConfigCategory defaults to CustomLogLevel ConfigCategory but can be passed in.
         /// Class and namespace overrides do not impact the LogLevel used for LogContent added with this method.
         /// </summary>
         /// <param name="logConfigSection">The ConfigSection from the CustomLogLevel ConfigCategory that the ConfigKey belongs to.</param>      
@@ -91,6 +93,7 @@ namespace StarWarsTracker.Logging.Abstraction
         /// <param name="description">The description to add to the LogContent. </param>
         /// <param name="extra">Optional object to be added to the LogContent. </param>
         /// <param name="methodCalling">Defaults to the name of the method that calls AddCritical().</param>
-        public void AddConfiguredLogLevel(string logConfigSection, string logConfigKey, string description, object? extra = null, [CallerMemberName] string methodCalling = "");
+        /// <param name="configCategory">Defaults to CustomLogLevels Category</param>
+        public void AddConfiguredLogLevel(string logConfigSection, string logConfigKey, string description, object? extra = null, string configCategory = Category.CustomLogLevels, [CallerMemberName] string methodCalling = "");
     }
 }

--- a/StarWarsTracker.Logging/Abstraction/ILogConfigReader.cs
+++ b/StarWarsTracker.Logging/Abstraction/ILogConfigReader.cs
@@ -1,4 +1,5 @@
-﻿using StarWarsTracker.Domain.Enums;
+﻿using StarWarsTracker.Domain.Constants.LogConfigs;
+using StarWarsTracker.Domain.Enums;
 
 namespace StarWarsTracker.Logging.Abstraction
 {
@@ -35,7 +36,7 @@ namespace StarWarsTracker.Logging.Abstraction
         /// <param name="configSection">The ConfigSection under CustomLogLevels Category to retrieve a LogLevel from.</param>
         /// <param name="configKeyName">The ConfigKey under the ConfigSection that the LogLevel being retrieved belongs to.</param>
         /// <returns>CustomLogLevel found using the configSection and configKeyName provided.</returns>
-        public LogLevel? GetCustomLogLevel(string configSection, string configKeyName);
+        public LogLevel? GetLogLevel(string configSection, string configKeyName, string configCategory = Category.CustomLogLevels);
 
         /// <summary>
         /// Return the current LoggingConfigs that are being used.

--- a/StarWarsTracker.Logging/Abstraction/ILogMessage.cs
+++ b/StarWarsTracker.Logging/Abstraction/ILogMessage.cs
@@ -28,18 +28,17 @@ namespace StarWarsTracker.Logging.Abstraction
         public LogLevel GetLevel();
 
         /// <summary>
-        /// Return the LogMessage as a JSON string with only LogContent that is above or equal to the LogLevel provided.
-        /// </summary>
-        /// <param name="logLevel">The lowest LogLevel of LogContent to be included in the response.</param>
-        /// <returns>JSON string of the LogMessage with ElapsedMilliseconds, LogStartTime, LogEndTime, LogLevel, NameOfLogLevel, and LogContents.</returns>
-        public string GetMessageJson(LogLevel logLevel);
-
-        /// <summary>
         /// Returns all the LogContent that has been added to the LogMessage that is equal to or greater than the logLevel provided.
         /// </summary>
         /// <param name="logLevel">The lowest LogLevel of LogContent to be included in the response.</param>
         /// <returns>Collection of LogContent belonging to the ILogMessage that is equal to or greater than the logLevel provided.</returns>
         public IEnumerable<LogContent> GetContent(LogLevel logLevel);
+
+        /// <summary>
+        /// Returns all the LogContent that has been added to the LogMessage
+        /// </summary>
+        /// <returns>Collection of LogContent belonging to the ILogMessage.</returns>
+        public IEnumerable<LogContent> GetAllContent();
 
         /// <summary>
         /// Returns the Elapsed Milliseconds since the LogMessage was initialized.

--- a/StarWarsTracker.Logging/DependencyInjection.cs
+++ b/StarWarsTracker.Logging/DependencyInjection.cs
@@ -2,11 +2,13 @@
 using StarWarsTracker.Logging.Abstraction;
 using StarWarsTracker.Logging.AppSettingsConfig;
 using StarWarsTracker.Logging.Implementation;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("StarWarsTracker.Logging.Tests")]
 namespace StarWarsTracker.Logging
 {
+    [ExcludeFromCodeCoverage]
     public static class DependencyInjection
     {
         public static IServiceCollection InjectLoggingDependencies(this IServiceCollection services, Dictionary<string, LogConfigSettings> configSettings)

--- a/StarWarsTracker.Logging/DependencyInjection.cs
+++ b/StarWarsTracker.Logging/DependencyInjection.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("StarWarsTracker.Logging.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 namespace StarWarsTracker.Logging
 {
     [ExcludeFromCodeCoverage]

--- a/StarWarsTracker.Logging/Implementation/ClassLogger.cs
+++ b/StarWarsTracker.Logging/Implementation/ClassLogger.cs
@@ -63,7 +63,7 @@ namespace StarWarsTracker.Logging.Implementation
             AddContent(_critical, description, extra, methodCalling);
 
         public void AddConfiguredLogLevel(string logConfigSection, string logConfigKey, string description, object? extra = null, [CallerMemberName] string methodCalling = "") =>            
-            AddContent(_logConfigReader.GetCustomLogLevel(logConfigSection, logConfigKey) ?? LogLevel.None, description, extra, methodCalling);
+            AddContent(_logConfigReader.GetLogLevel(logConfigSection, logConfigKey) ?? LogLevel.None, description, extra, methodCalling);
 
         public void IncreaseLevel(LogLevel logLevel, string description, object? extra = null, [CallerMemberName] string methodCalling = "") =>
             _logMessage.IncreaseLevel(new(logLevel, _className, _namespaceName, methodCalling, description, extra, _logMessage.GetElapsedMilliseconds()));

--- a/StarWarsTracker.Logging/Implementation/ClassLogger.cs
+++ b/StarWarsTracker.Logging/Implementation/ClassLogger.cs
@@ -48,7 +48,6 @@ namespace StarWarsTracker.Logging.Implementation
 
         public void AddDebug(string description, object? extra = null, [CallerMemberName] string methodCalling = "") =>
             AddContent(_debug, description, extra, methodCalling);
-
         
         public void AddInfo(string description, object? extra = null, [CallerMemberName] string methodCalling = "") =>
             AddContent(_info, description, extra, methodCalling);
@@ -62,8 +61,8 @@ namespace StarWarsTracker.Logging.Implementation
         public void AddCritical(string description, object? extra = null, [CallerMemberName] string methodCalling = "") =>
             AddContent(_critical, description, extra, methodCalling);
 
-        public void AddConfiguredLogLevel(string logConfigSection, string logConfigKey, string description, object? extra = null, [CallerMemberName] string methodCalling = "") =>            
-            AddContent(_logConfigReader.GetLogLevel(logConfigSection, logConfigKey) ?? LogLevel.None, description, extra, methodCalling);
+        public void AddConfiguredLogLevel(string logConfigSection, string logConfigKey, string description, object? extra = null, string configCategory = Category.CustomLogLevels, [CallerMemberName] string methodCalling = "") =>            
+            AddContent(_logConfigReader.GetLogLevel(logConfigSection, logConfigKey, configCategory) ?? LogLevel.None, description, extra, methodCalling);
 
         public void IncreaseLevel(LogLevel logLevel, string description, object? extra = null, [CallerMemberName] string methodCalling = "") =>
             _logMessage.IncreaseLevel(new(logLevel, _className, _namespaceName, methodCalling, description, extra, _logMessage.GetElapsedMilliseconds()));
@@ -98,14 +97,7 @@ namespace StarWarsTracker.Logging.Implementation
         {
             var allNameSpaceOverrides = _logConfigReader.GetConfigCategory(Category.OverrideLogLevelByNameSpace);
 
-            Dictionary<string, LogLevel> nameSpaceOverrides = null!;
-
-            var qualifyingNameSpaceOverrides = allNameSpaceOverrides?.Where(_ => _namespaceName.Equals(_.Key, StringComparison.OrdinalIgnoreCase));
-
-            if (qualifyingNameSpaceOverrides?.Any() ?? false)
-            {
-                nameSpaceOverrides = qualifyingNameSpaceOverrides.OrderBy(_ => _.Key.Length).First().Value;
-            }
+            var nameSpaceOverrides = allNameSpaceOverrides?.FirstOrDefault(_ => _.Key.Equals(_namespaceName, StringComparison.OrdinalIgnoreCase)).Value;
 
             return nameSpaceOverrides;
         }

--- a/StarWarsTracker.Logging/Implementation/LogConfigReader.cs
+++ b/StarWarsTracker.Logging/Implementation/LogConfigReader.cs
@@ -34,8 +34,8 @@ namespace StarWarsTracker.Logging.Implementation
         public Dictionary<string, LogLevel>? GetConfigSection(string configCategory, string configSection) =>
             GetConfigCategory(configCategory)?.TryGetValue(configSection, out var section) ?? false ? section : null;
 
-        public LogLevel? GetCustomLogLevel(string configSection, string configKeyName) =>
-            GetConfigSection(Category.CustomLogLevels, configSection)?.TryGetValue(configKeyName, out var level) ?? false ? level : null;
+        public LogLevel? GetLogLevel(string configSection, string configKeyName, string configCategory = Category.CustomLogLevels) =>
+            GetConfigSection(configCategory, configSection)?.TryGetValue(configKeyName, out var level) ?? false ? level : null;
 
         public bool TrySetEndpointConfigs(string endpoint)
         {

--- a/StarWarsTracker.Logging/Implementation/LogMessage.cs
+++ b/StarWarsTracker.Logging/Implementation/LogMessage.cs
@@ -1,7 +1,6 @@
 ﻿using StarWarsTracker.Domain.Enums;
 using StarWarsTracker.Logging.Abstraction;
 using System.Diagnostics;
-using System.Text.Json;
 
 namespace StarWarsTracker.Logging.Implementation
 {
@@ -12,8 +11,6 @@ namespace StarWarsTracker.Logging.Implementation
         private readonly List<LogContent> _logContents = new();
 
         private LogLevel _logLevel = LogLevel.Trace;
-
-        private readonly DateTime _dateTimeCreatedUTC = DateTime.UtcNow;
 
         private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
 
@@ -27,32 +24,6 @@ namespace StarWarsTracker.Logging.Implementation
             {
                 _logContents.Add(logContent);
             }
-        }
-
-        public string GetMessageJson(LogLevel logLevel)
-        {
-            if (logLevel == LogLevel.None)
-            {
-                return string.Empty;
-            }
-
-            var messagesToLog = _logContents.Where(_ => _.LogLevel >= logLevel);
-
-            var currentTime = DateTime.UtcNow;
-
-            var logContent = new
-            {
-                ElapsedMilliseconds = GetElapsedMilliseconds(),
-                LogStartTime = _dateTimeCreatedUTC,
-                LogEndTime = currentTime,
-                LogLevel = _logLevel,
-                NameOfLogLevel = _logLevel.ToString(),
-                LogContents = messagesToLog
-            };
-
-            var jsonContent = JsonSerializer.Serialize(logContent);
-
-            return jsonContent;
         }
 
         public double GetElapsedMilliseconds() => _stopwatch.Elapsed.TotalMilliseconds;
@@ -76,6 +47,8 @@ namespace StarWarsTracker.Logging.Implementation
 
         public IEnumerable<LogContent> GetContent(LogLevel logLevel) =>
             logLevel == LogLevel.None ? Enumerable.Empty<LogContent>() : _logContents.Where(_ => _.LogLevel >= logLevel);
+
+        public IEnumerable<LogContent> GetAllContent() => _logContents;
 
         #endregion
     }

--- a/StarWarsTracker.Persistence/Implementation/DataAccess.cs
+++ b/StarWarsTracker.Persistence/Implementation/DataAccess.cs
@@ -102,7 +102,7 @@ namespace StarWarsTracker.Persistence.Implementation
         /// </summary>
         private void LogRequest<T>(string logConfigSection, T request, [CallerMemberName] string methodCalling = "") where T : IDataRequest
         {
-            var logDetailLevel = _logConfigReader.GetCustomLogLevel(logConfigSection, Key.SqlRequestLogDetails);
+            var logDetailLevel = _logConfigReader.GetLogLevel(logConfigSection, Key.SqlRequestLogDetails);
 
             object? extra = logDetailLevel switch
             {
@@ -126,7 +126,7 @@ namespace StarWarsTracker.Persistence.Implementation
         /// </summary>
         private void LogResponse<T>(string logConfigSection, T? response, [CallerMemberName] string methodCalling = "")
         {
-            var logDetailLevel = _logConfigReader.GetCustomLogLevel(logConfigSection, Key.SqlResponseLogDetails);
+            var logDetailLevel = _logConfigReader.GetLogLevel(logConfigSection, Key.SqlResponseLogDetails);
 
             object? extra = logDetailLevel switch
             {


### PR DESCRIPTION
## Small Refactors

- Removed LogMessage.GetMessageJson() which was replaced by LogMessage.GetContent() previously. 
- Added GetAllContent() to ILogMessage/LogMessage 
- Renamed LogConfigReader.GetCustomLog Level to GetLogLevel and allowed CategoryKey to be passed in but defaults to CustomLogLevel constant. 
- Implemented optional ConfigCategory for ClassLogger.AddConfiguredLogLevel which defaults to constant value for Category.CustomLogLevels 
   - similar to what was implemented on ILogConfigReader.

## Increased Test Coverage around Logging layer

- Added more tests for LogMessage. 
- Added tests for LogConfig Settings/Category/Section 

- Added tests for LogConfig

- Added Tests for LogConfigReader. 

- Added tests for ClassLoggerFactory

- Added tests for ClassLogger

## Excluded items from FineCodeCoverage

- Excluded DependencyInjection from FineCodeCoverage
- Excluded LoggingMiddleware from FineCodeCoverage.