### PR TITLE
DAguirre - Setting Up Swagger Examples

### DIFF
--- a/StarWarsTracker.Api.Tests/IntegrationTests/EventControllerTests/DeleteEventTests.cs
+++ b/StarWarsTracker.Api.Tests/IntegrationTests/EventControllerTests/DeleteEventTests.cs
@@ -43,5 +43,11 @@ namespace StarWarsTracker.Api.Tests.IntegrationTests.EventControllerTests
             // Assert that attempting to fetch the event after inserting throws a does not exist exception
             Assert.NotNull(doesNotExistExceptionAfterDeleting);
         }
+
+        [Fact]
+        public async Task DeleteEvent_Given_NullRequest_ShouldThrow_ValidationFailureException()
+        {
+            await Assert.ThrowsAsync<ValidationFailureException>(async () => await _controller.DeleteEvent(null!));
+        }
     }
 }

--- a/StarWarsTracker.Api.Tests/IntegrationTests/EventControllerTests/GetAllEventsNotHavingDatesTests.cs
+++ b/StarWarsTracker.Api.Tests/IntegrationTests/EventControllerTests/GetAllEventsNotHavingDatesTests.cs
@@ -9,7 +9,7 @@ namespace StarWarsTracker.Api.Tests.IntegrationTests.EventControllerTests
         {
             var existingEventWithoutDates = await TestEvent.InsertAndFetchEventAsync();
 
-            var response = await _controller.GetAllEventsNotHavingDates(new());
+            var response = await _controller.GetAllEventsNotHavingDates();
 
             await _controller.DeleteEvent(new(existingEventWithoutDates.Guid));
 
@@ -31,7 +31,7 @@ namespace StarWarsTracker.Api.Tests.IntegrationTests.EventControllerTests
         {
             var (existingEventWithDates, _) = await TestEventDate.InsertAndFetchEventDateAsync();
 
-            var response = await _controller.GetAllEventsNotHavingDates(new());
+            var response = await _controller.GetAllEventsNotHavingDates();
 
             await _controller.DeleteEvent(new(existingEventWithDates.Guid));
 

--- a/StarWarsTracker.Api.Tests/IntegrationTests/EventControllerTests/GetEventsByYearTests.cs
+++ b/StarWarsTracker.Api.Tests/IntegrationTests/EventControllerTests/GetEventsByYearTests.cs
@@ -53,5 +53,11 @@ namespace StarWarsTracker.Api.Tests.IntegrationTests.EventControllerTests
             Assert.Equal(secondEventDuringYear.Description, secondEventResponse.Description);
             Assert.Equal(secondEventDuringYear.CanonTypeId, (int)secondEventResponse.CanonType);
         }
+
+        [Fact]
+        public async Task GetEventsByYear_Given_Null_ShouldThrow_ValidationFailedException()
+        {
+            await Assert.ThrowsAsync<ValidationFailureException>(async () => await _controller.GetEventsByYear(null!));
+        }
     }
 }

--- a/StarWarsTracker.Api/Controllers/BaseController.cs
+++ b/StarWarsTracker.Api/Controllers/BaseController.cs
@@ -1,4 +1,5 @@
 ﻿using StarWarsTracker.Domain.Constants.LogConfigs;
+using StarWarsTracker.Domain.Exceptions;
 using StarWarsTracker.Logging.Abstraction;
 using System.Runtime.CompilerServices;
 
@@ -29,6 +30,12 @@ namespace StarWarsTracker.Api.Controllers
 
         public async Task ExecuteRequestAsync(IRequest request, [CallerMemberName] string methodCalling = "")
         {
+            if (request == null)
+            {
+                _logger.AddDebug("Null Request Received", typeof(IRequest).Name);
+                throw new ValidationFailureException("Null Request Received");
+            }
+
             LogRequest(request, methodCalling);
 
             await _orchestrator.ExecuteRequestAsync(request);
@@ -38,6 +45,12 @@ namespace StarWarsTracker.Api.Controllers
 
         public async Task<TResponse> GetResponseAsync<TResponse>(IRequestResponse<TResponse> request, [CallerMemberName] string methodCalling = "")
         {
+            if (request == null)
+            {
+                _logger.AddDebug("Null Request Received", typeof(IRequest).Name);
+                throw new ValidationFailureException("Null Request Received");
+            }
+
             LogRequest(request, methodCalling);
 
             var response = await _orchestrator.GetRequestResponseAsync(request);

--- a/StarWarsTracker.Api/Controllers/BaseController.cs
+++ b/StarWarsTracker.Api/Controllers/BaseController.cs
@@ -26,9 +26,9 @@ namespace StarWarsTracker.Api.Controllers
 
         #endregion
 
-        #region Public Methods
+        #region Protected Methods
 
-        public async Task ExecuteRequestAsync(IRequest request, [CallerMemberName] string methodCalling = "")
+        protected async Task ExecuteRequestAsync(IRequest request, [CallerMemberName] string methodCalling = "")
         {
             if (request == null)
             {
@@ -43,7 +43,7 @@ namespace StarWarsTracker.Api.Controllers
             LogResponse(null, methodCalling);
         }
 
-        public async Task<TResponse> GetResponseAsync<TResponse>(IRequestResponse<TResponse> request, [CallerMemberName] string methodCalling = "")
+        protected async Task<TResponse> GetResponseAsync<TResponse>(IRequestResponse<TResponse> request, [CallerMemberName] string methodCalling = "")
         {
             if (request == null)
             {

--- a/StarWarsTracker.Api/Controllers/EventController.cs
+++ b/StarWarsTracker.Api/Controllers/EventController.cs
@@ -46,7 +46,7 @@ namespace StarWarsTracker.Api.Controllers
 
         [HttpGet(EventRoute.GetNotHavingDates),
             SwaggerOperation("Get all Star Wars Events that do not have an EventDate saved."),
-            SuccessResponse(typeof(GetAllEventsNotHavingDatesResponse))]
+            SuccessResponse(typeof(GetAllEventsNotHavingDatesResponse)), SuccessResponseExample(typeof(GetAllEventsNotHavingDatesExample.SuccessResponse))]
         public async Task<GetAllEventsNotHavingDatesResponse> GetAllEventsNotHavingDates() => await GetResponseAsync(new GetAllEventsNotHavingDatesRequest());
 
         #endregion
@@ -55,9 +55,9 @@ namespace StarWarsTracker.Api.Controllers
 
         [HttpGet(EventRoute.GetByGuid),
             SwaggerOperation("Get a specific Event and its Timeline using the EventGuid Identifier."),
-            SuccessResponse(), SuccessResponseExample(typeof(GetEventByGuidExample.SuccessResponse)),
+            SuccessResponse(typeof(GetEventByGuidResponse)), SuccessResponseExample(typeof(GetEventByGuidExample.SuccessResponse)),
             ValidationFailedResponse(), ValidationFailedExample(typeof(GetEventByGuidExample.BadRequest)),
-            DoesNotExistResponse()]
+            DoesNotExistResponse(), DoesNotExistExample(typeof(GetEventByGuidExample.DoesNotExist))]
         public async Task<GetEventByGuidResponse> GetEventByGuid(GetEventByGuidRequest request) => await GetResponseAsync(request);
 
         #endregion
@@ -66,7 +66,7 @@ namespace StarWarsTracker.Api.Controllers
 
         [HttpGet(EventRoute.GetByNameAndCanonType),
             SwaggerOperation("Search for a specific Event by specifying the Event's Name and the CanonType"),
-            SuccessResponse(),
+            SuccessResponse(typeof(GetEventByNameAndCanonTypeResponse)), SuccessResponseExample(typeof(GetEventByNameAndCanonTypeExample.SuccessResponse)),
             ValidationFailedResponse(), ValidationFailedExample(typeof(GetEventByNameAndCanonTypeExample.BadRequest)),
             DoesNotExistResponse(), DoesNotExistExample((typeof(GetEventByNameAndCanonTypeExample.DoesNotExist)))]
         public async Task<GetEventByNameAndCanonTypeResponse> GetEventByNameAndCanonType(GetEventByNameAndCanonTypeRequest request) => await GetResponseAsync(request);
@@ -77,7 +77,7 @@ namespace StarWarsTracker.Api.Controllers
 
         [HttpGet(EventRoute.GetByNameLike),
             SwaggerOperation("Get a list of Events where the name contains the Name provided."),
-            SuccessResponse(), SuccessResponseExample(typeof(GetEventByGuidExample.SuccessResponse)),
+            SuccessResponse(typeof(GetEventsByNameLikeResponse)), SuccessResponseExample(typeof(GetEventsByNameLikeExample.SuccessResponse)),
             ValidationFailedResponse(), ValidationFailedExample(typeof(GetEventsByNameLikeExample.BadRequest)),
             DoesNotExistResponse(), DoesNotExistExample(typeof(GetEventsByNameLikeExample.DoesNotExist))]
         public async Task<GetEventsByNameLikeResponse> GetEventsByNameLike(GetEventsByNameLikeRequest request) => await GetResponseAsync(request);
@@ -88,7 +88,7 @@ namespace StarWarsTracker.Api.Controllers
 
         [HttpGet(EventRoute.GetByYear),
             SwaggerOperation("Get a list of Events that happen during a specific year."),
-            SuccessResponse(), SuccessResponseExample(typeof(GetEventsByYearExample.SuccessResponse)),
+            SuccessResponse(typeof(GetEventsByYearResponse)), SuccessResponseExample(typeof(GetEventsByYearExample.SuccessResponse)),
             DoesNotExistResponse(), DoesNotExistExample(typeof(GetEventsByYearExample.DoesNotExist))]
         public async Task<GetEventsByYearResponse> GetEventsByYear(GetEventsByYearRequest request) => await GetResponseAsync(request);
 

--- a/StarWarsTracker.Api/Controllers/EventController.cs
+++ b/StarWarsTracker.Api/Controllers/EventController.cs
@@ -1,4 +1,7 @@
-﻿using StarWarsTracker.Application.Requests.EventRequests.Delete;
+﻿using StarWarsTracker.Api.Examples.Events;
+using StarWarsTracker.Api.SwaggerHelpers.Attributes;
+using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
+using StarWarsTracker.Application.Requests.EventRequests.Delete;
 using StarWarsTracker.Application.Requests.EventRequests.GetAllNotHavingDates;
 using StarWarsTracker.Application.Requests.EventRequests.GetByGuid;
 using StarWarsTracker.Application.Requests.EventRequests.GetByNameAndCanonType;
@@ -7,6 +10,8 @@ using StarWarsTracker.Application.Requests.EventRequests.GetByYear;
 using StarWarsTracker.Application.Requests.EventRequests.Insert;
 using StarWarsTracker.Domain.Constants.Routes;
 using StarWarsTracker.Logging.Abstraction;
+using Swashbuckle.AspNetCore.Annotations;
+using Swashbuckle.AspNetCore.Filters;
 
 namespace StarWarsTracker.Api.Controllers
 {
@@ -14,25 +19,80 @@ namespace StarWarsTracker.Api.Controllers
     {
         public EventController(IOrchestrator orchestrator, IClassLoggerFactory loggerFactory) : base(orchestrator, loggerFactory) { }
 
-        [HttpPost(EventRoute.Insert)]
-        public async Task InsertEvent(InsertEventRequest request) => await ExecuteRequestAsync(request);
+        #region Insert Event Endpoint 
 
-        [HttpDelete(EventRoute.Delete)]
+        [HttpPost(EventRoute.Insert),
+            SwaggerOperation("Insert a Star Wars Event into the database."),
+            SuccessResponse(),
+            SwaggerRequestExample(typeof(InsertEventRequest), typeof(InsertEventExample.ValidRequest)),
+            ValidationFailedResponse(), ValidationFailedExample(typeof(InsertEventExample.BadRequest)),
+            AlreadyExistsResponse(), AlreadyExistsExample(typeof(InsertEventExample.AlreadyExists))]
+        public async Task InsertEvent([FromBody] InsertEventRequest request) => await ExecuteRequestAsync(request);
+
+        #endregion
+
+        #region Delete Event Endpoint
+
+        [HttpDelete(EventRoute.Delete),
+            SwaggerOperation("Delete a Star Wars Event using the EventGuid Identifier."),
+            SuccessResponse(),
+            ValidationFailedResponse(), ValidationFailedExample(typeof(DeleteEventExample.BadRequest)),
+            DoesNotExistResponse(), DoesNotExistExample(typeof(DeleteEventExample.DoesNotExist))]
         public async Task DeleteEvent(DeleteEventByGuidRequest request) => await ExecuteRequestAsync(request);
 
-        [HttpGet(EventRoute.GetNotHavingDates)]
-        public async Task<GetAllEventsNotHavingDatesResponse> GetAllEventsNotHavingDates(GetAllEventsNotHavingDatesRequest request) => await GetResponseAsync(request);
+        #endregion
 
-        [HttpGet(EventRoute.GetByGuid)]
+        #region Get All Events Not Having Dates Endpoint
+
+        [HttpGet(EventRoute.GetNotHavingDates),
+            SwaggerOperation("Get all Star Wars Events that do not have an EventDate saved."),
+            SuccessResponse(typeof(GetAllEventsNotHavingDatesResponse))]
+        public async Task<GetAllEventsNotHavingDatesResponse> GetAllEventsNotHavingDates() => await GetResponseAsync(new GetAllEventsNotHavingDatesRequest());
+
+        #endregion
+
+        #region Get Event By Guid Endpoint
+
+        [HttpGet(EventRoute.GetByGuid),
+            SwaggerOperation("Get a specific Event and its Timeline using the EventGuid Identifier."),
+            SuccessResponse(), SuccessResponseExample(typeof(GetEventByGuidExample.SuccessResponse)),
+            ValidationFailedResponse(), ValidationFailedExample(typeof(GetEventByGuidExample.BadRequest)),
+            DoesNotExistResponse()]
         public async Task<GetEventByGuidResponse> GetEventByGuid(GetEventByGuidRequest request) => await GetResponseAsync(request);
 
-        [HttpGet(EventRoute.GetByNameAndCanonType)]
+        #endregion
+
+        #region Get Event By Name And Canon Type
+
+        [HttpGet(EventRoute.GetByNameAndCanonType),
+            SwaggerOperation("Search for a specific Event by specifying the Event's Name and the CanonType"),
+            SuccessResponse(),
+            ValidationFailedResponse(), ValidationFailedExample(typeof(GetEventByNameAndCanonTypeExample.BadRequest)),
+            DoesNotExistResponse(), DoesNotExistExample((typeof(GetEventByNameAndCanonTypeExample.DoesNotExist)))]
         public async Task<GetEventByNameAndCanonTypeResponse> GetEventByNameAndCanonType(GetEventByNameAndCanonTypeRequest request) => await GetResponseAsync(request);
 
-        [HttpGet(EventRoute.GetByNameLike)]
+        #endregion
+
+        #region Get Events By Name Like
+
+        [HttpGet(EventRoute.GetByNameLike),
+            SwaggerOperation("Get a list of Events where the name contains the Name provided."),
+            SuccessResponse(), SuccessResponseExample(typeof(GetEventByGuidExample.SuccessResponse)),
+            ValidationFailedResponse(), ValidationFailedExample(typeof(GetEventsByNameLikeExample.BadRequest)),
+            DoesNotExistResponse(), DoesNotExistExample(typeof(GetEventsByNameLikeExample.DoesNotExist))]
         public async Task<GetEventsByNameLikeResponse> GetEventsByNameLike(GetEventsByNameLikeRequest request) => await GetResponseAsync(request);
 
-        [HttpGet(EventRoute.GetByYear)]
+        #endregion
+
+        #region Get Events By Year
+
+        [HttpGet(EventRoute.GetByYear),
+            SwaggerOperation("Get a list of Events that happen during a specific year."),
+            SuccessResponse(), SuccessResponseExample(typeof(GetEventsByYearExample.SuccessResponse)),
+            DoesNotExistResponse(), DoesNotExistExample(typeof(GetEventsByYearExample.DoesNotExist))]
         public async Task<GetEventsByYearResponse> GetEventsByYear(GetEventsByYearRequest request) => await GetResponseAsync(request);
+
+        #endregion
+
     }
 }

--- a/StarWarsTracker.Api/Controllers/EventController.cs
+++ b/StarWarsTracker.Api/Controllers/EventController.cs
@@ -62,7 +62,7 @@ namespace StarWarsTracker.Api.Controllers
 
         #endregion
 
-        #region Get Event By Name And Canon Type
+        #region Get Event By Name And Canon Type Endpoint
 
         [HttpGet(EventRoute.GetByNameAndCanonType),
             SwaggerOperation("Search for a specific Event by specifying the Event's Name and the CanonType"),
@@ -73,7 +73,7 @@ namespace StarWarsTracker.Api.Controllers
 
         #endregion
 
-        #region Get Events By Name Like
+        #region Get Events By Name Like Endpoint
 
         [HttpGet(EventRoute.GetByNameLike),
             SwaggerOperation("Get a list of Events where the name contains the Name provided."),
@@ -84,7 +84,7 @@ namespace StarWarsTracker.Api.Controllers
 
         #endregion
 
-        #region Get Events By Year
+        #region Get Events By Year Endpoint
 
         [HttpGet(EventRoute.GetByYear),
             SwaggerOperation("Get a list of Events that happen during a specific year."),

--- a/StarWarsTracker.Api/Examples/Events/DeleteEventExample.cs
+++ b/StarWarsTracker.Api/Examples/Events/DeleteEventExample.cs
@@ -1,0 +1,27 @@
+﻿using StarWarsTracker.Api.SwaggerHelpers.ExampleProviders;
+using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
+using StarWarsTracker.Application.Requests.EventRequests.Delete;
+using StarWarsTracker.Domain.Exceptions;
+using StarWarsTracker.Domain.Models;
+using StarWarsTracker.Domain.Validation;
+
+namespace StarWarsTracker.Api.Examples.Events
+{
+    public class DeleteEventExample
+    {
+        public class BadRequest : DeleteEventByGuidRequest, IValidationFailureExample
+        {
+            public ValidationFailureResponse GetExamples() => new(ValidationFailureMessage.RequiredField(nameof(EventGuid)));
+        }
+
+        public class DoesNotExist : DeleteEventByGuidRequest, IDoesNotExistExample
+        {
+            public DoesNotExistResponse GetExamples() =>
+                new(
+                    nameof(Event),
+                    (Guid.NewGuid(), nameof(EventGuid))
+                );
+        }
+
+    }
+}

--- a/StarWarsTracker.Api/Examples/Events/GetAllEventsNotHavingDatesExample.cs
+++ b/StarWarsTracker.Api/Examples/Events/GetAllEventsNotHavingDatesExample.cs
@@ -1,0 +1,27 @@
+﻿using StarWarsTracker.Api.SwaggerHelpers.ExampleProviders;
+using StarWarsTracker.Application.Requests.EventRequests.GetAllNotHavingDates;
+using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Domain.Models;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace StarWarsTracker.Api.Examples.Events
+{
+    public class GetAllEventsNotHavingDatesExample
+    {
+        public class SuccessResponse : IManyExamples<GetAllEventsNotHavingDatesResponse>
+        {
+            public IEnumerable<SwaggerExample<GetAllEventsNotHavingDatesResponse>> GetExamples() =>
+                new[]
+                {
+                    SwaggerExample.Create("Events Found",
+                        new GetAllEventsNotHavingDatesResponse(new[]
+                        {
+                            new Event(Guid.NewGuid(), "Name Of An Event Without A Date", "A mysterious Event that nobody knows when it happened.", CanonType.StrictlyCanon),
+                            new Event(Guid.NewGuid(), "Yet Another Event Without A Date", "Not even Yoda knows when this happened.", CanonType.StrictlyLegends),
+                        })),
+                    SwaggerExample.Create("Events Not Found",
+                        new GetAllEventsNotHavingDatesResponse())
+                };
+        }
+    }
+}

--- a/StarWarsTracker.Api/Examples/Events/GetEventByGuidExample.cs
+++ b/StarWarsTracker.Api/Examples/Events/GetEventByGuidExample.cs
@@ -2,6 +2,7 @@
 using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
 using StarWarsTracker.Application.Requests.EventRequests.GetByGuid;
 using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Domain.Exceptions;
 using StarWarsTracker.Domain.Models;
 using StarWarsTracker.Domain.Validation;
 
@@ -13,7 +14,7 @@ namespace StarWarsTracker.Api.Examples.Events
         {
             public GetEventByGuidResponse GetExamples() =>
                 new(
-                   new Event(Guid.NewGuid(), "Name Of A Recently Identified Event", "This is a description of an Event", CanonType.StrictlyCanon),
+                   new Event(Guid.NewGuid(), "Name Of Event", "This is a description of an Event found using the Guid provided.", CanonType.StrictlyCanon),
                    new EventTimeFrame(new EventDate(EventDateType.Definitive, -10, 45))
                    );
         }
@@ -21,6 +22,11 @@ namespace StarWarsTracker.Api.Examples.Events
         public class BadRequest : GetEventByGuidRequest, IValidationFailureExample
         {
             public ValidationFailureResponse GetExamples() => new(ValidationFailureMessage.RequiredField(nameof(EventGuid)));
+        }
+
+        public class DoesNotExist : GetEventByGuidRequest, IDoesNotExistExample
+        {
+            public DoesNotExistResponse GetExamples() => new(nameof(Event), (Guid.NewGuid(), nameof(EventGuid)));
         }
     }
 }

--- a/StarWarsTracker.Api/Examples/Events/GetEventByGuidExample.cs
+++ b/StarWarsTracker.Api/Examples/Events/GetEventByGuidExample.cs
@@ -1,0 +1,26 @@
+﻿using StarWarsTracker.Api.SwaggerHelpers.ExampleProviders;
+using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
+using StarWarsTracker.Application.Requests.EventRequests.GetByGuid;
+using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Domain.Models;
+using StarWarsTracker.Domain.Validation;
+
+namespace StarWarsTracker.Api.Examples.Events
+{
+    public class GetEventByGuidExample 
+    {
+        public class SuccessResponse : GetEventByGuidRequest, IExample<GetEventByGuidResponse>
+        {
+            public GetEventByGuidResponse GetExamples() =>
+                new(
+                   new Event(Guid.NewGuid(), "Name Of A Recently Identified Event", "This is a description of an Event", CanonType.StrictlyCanon),
+                   new EventTimeFrame(new EventDate(EventDateType.Definitive, -10, 45))
+                   );
+        }
+
+        public class BadRequest : GetEventByGuidRequest, IValidationFailureExample
+        {
+            public ValidationFailureResponse GetExamples() => new(ValidationFailureMessage.RequiredField(nameof(EventGuid)));
+        }
+    }
+}

--- a/StarWarsTracker.Api/Examples/Events/GetEventByNameAndCanonTypeExample.cs
+++ b/StarWarsTracker.Api/Examples/Events/GetEventByNameAndCanonTypeExample.cs
@@ -11,6 +11,12 @@ namespace StarWarsTracker.Api.Examples.Events
 {
     public class GetEventByNameAndCanonTypeExample
     {
+        public class SuccessResponse : IExample<GetEventByNameAndCanonTypeResponse>
+        {
+            public GetEventByNameAndCanonTypeResponse GetExamples() =>
+                new(new Event(Guid.NewGuid(), "Name Of Event Found", "This Event Brought To You By Event Name And Canon Type Match", CanonType.StrictlyCanon));
+        }
+
         public class BadRequest : GetEventByNameAndCanonTypeRequest, IManyValidationFailureExamples
         {
             public IEnumerable<SwaggerExample<ValidationFailureResponse>> GetExamples() =>

--- a/StarWarsTracker.Api/Examples/Events/GetEventByNameAndCanonTypeExample.cs
+++ b/StarWarsTracker.Api/Examples/Events/GetEventByNameAndCanonTypeExample.cs
@@ -1,0 +1,40 @@
+﻿using StarWarsTracker.Api.SwaggerHelpers.ExampleProviders;
+using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
+using StarWarsTracker.Application.Requests.EventRequests.GetByNameAndCanonType;
+using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Domain.Exceptions;
+using StarWarsTracker.Domain.Models;
+using StarWarsTracker.Domain.Validation;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace StarWarsTracker.Api.Examples.Events
+{
+    public class GetEventByNameAndCanonTypeExample
+    {
+        public class BadRequest : GetEventByNameAndCanonTypeRequest, IManyValidationFailureExamples
+        {
+            public IEnumerable<SwaggerExample<ValidationFailureResponse>> GetExamples() =>
+                new[]
+                {
+                     SwaggerExample.Create("No Fields Provided",
+                        new ValidationFailureResponse(
+                            ValidationFailureMessage.RequiredField(nameof(Name)), 
+                            ValidationFailureMessage.InvalidValue(0, nameof(CanonType))
+                        )),
+                    SwaggerExample.Create("Name Not Provided",
+                        new ValidationFailureResponse(
+                            ValidationFailureMessage.RequiredField(nameof(Name))
+                        )),
+                    SwaggerExample.Create("CanonType Not Provided",
+                        new ValidationFailureResponse(
+                            ValidationFailureMessage.InvalidValue(0, nameof(CanonType))
+                        ))
+                };
+        }
+
+        public class DoesNotExist : GetEventByNameAndCanonTypeRequest, IDoesNotExistExample
+        {
+            public DoesNotExistResponse GetExamples() => new(nameof(Event), ("Name Of Event Searched For", nameof(Name)), (CanonType.StrictlyCanon, nameof(CanonType)));
+        }
+    }
+}

--- a/StarWarsTracker.Api/Examples/Events/GetEventsByNameLikeExample.cs
+++ b/StarWarsTracker.Api/Examples/Events/GetEventsByNameLikeExample.cs
@@ -1,0 +1,35 @@
+﻿using StarWarsTracker.Api.SwaggerHelpers.ExampleProviders;
+using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
+using StarWarsTracker.Application.Requests.EventRequests.GetByNameLike;
+using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Domain.Exceptions;
+using StarWarsTracker.Domain.Models;
+using StarWarsTracker.Domain.Validation;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace StarWarsTracker.Api.Examples.Events
+{
+    public class GetEventsByNameLikeExample
+    {
+        public class BadRequest : GetEventsByNameLikeRequest, IValidationFailureExample
+        {
+            public ValidationFailureResponse GetExamples() => new(ValidationFailureMessage.RequiredField(nameof(Name)));
+        }
+
+        public class DoesNotExist : GetEventsByNameLikeRequest, IDoesNotExistExample
+        {
+            public DoesNotExistResponse GetExamples() => new(nameof(Event), ("Name Searched By", nameof(Name)));
+        }
+
+        public class SuccessResponse : IExample<GetEventsByNameLikeResponse>
+        {
+            public GetEventsByNameLikeResponse GetExamples() => new(
+                new Event[]
+                {
+                new (Guid.NewGuid(), "Battle At Some Example Planet", "This Example Found due to having Battle in the Name", CanonType.StrictlyCanon),
+                new (Guid.NewGuid(), "Battle At Some Other Example Planet", "This Battle is another example Event", CanonType.StrictlyLegends),
+                new (Guid.NewGuid(), "Battle At Yet Another Example Planet", "This is yet another Example Event", CanonType.CanonAndLegends),
+                });
+        }
+    }
+}

--- a/StarWarsTracker.Api/Examples/Events/GetEventsByYearExample.cs
+++ b/StarWarsTracker.Api/Examples/Events/GetEventsByYearExample.cs
@@ -1,0 +1,26 @@
+﻿using StarWarsTracker.Api.SwaggerHelpers.ExampleProviders;
+using StarWarsTracker.Application.Requests.EventRequests.GetByYear;
+using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Domain.Exceptions;
+using StarWarsTracker.Domain.Models;
+
+namespace StarWarsTracker.Api.Examples.Events
+{
+    public class GetEventsByYearExample
+    {
+        public class SuccessResponse : IExample<GetEventsByYearResponse>
+        {
+            public GetEventsByYearResponse GetExamples() =>
+                new(new Event[]
+                {
+                    new(Guid.NewGuid(), "The Death Of Count Dooku", "Count Dooku Died at the hands of Anakin Skywalker", CanonType.CanonAndLegends),
+                    new(Guid.NewGuid(), "The Death Of General Grievous", "General Grievous was brought to an end by Obi Wan Kenobi", CanonType.CanonAndLegends)
+                });
+        }
+
+        public class DoesNotExist : GetEventsByYearRequest, IDoesNotExistExample
+        {
+            public DoesNotExistResponse GetExamples() => new(nameof(Event), (-19, nameof(YearsSinceBattleOfYavin)));
+        }
+    }
+}

--- a/StarWarsTracker.Api/Examples/Events/InsertEventExample.cs
+++ b/StarWarsTracker.Api/Examples/Events/InsertEventExample.cs
@@ -1,0 +1,56 @@
+﻿using StarWarsTracker.Api.SwaggerHelpers.ExampleProviders;
+using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
+using StarWarsTracker.Application.Requests.EventRequests.Insert;
+using StarWarsTracker.Domain.Enums;
+using StarWarsTracker.Domain.Models;
+using StarWarsTracker.Domain.Validation;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace StarWarsTracker.Api.Examples.Events
+{
+    public class InsertEventExample
+    {
+        public class ValidRequest : IExample<InsertEventRequest>
+        {
+            public InsertEventRequest GetExamples() =>
+               new("Name Of New Event", "Description For New Event", CanonType.StrictlyCanon);
+
+        }
+
+        public class AlreadyExists : InsertEventRequest, IAlreadyExistExample
+        {
+            public AlreadyExistsResponse GetExamples() =>
+                new(nameof(Event),
+                    (CanonType.StrictlyCanon, nameof(CanonType)),
+                    ("Name Of Event", nameof(Name)));
+
+        }
+
+        public class BadRequest : InsertEventRequest, IManyValidationFailureExamples
+        {
+            public IEnumerable<SwaggerExample<ValidationFailureResponse>> GetExamples() =>
+                new[]
+                    {
+                    SwaggerExample.Create("Missing All Required Fields",
+                       new ValidationFailureResponse(
+                           ValidationFailureMessage.RequiredField(nameof(Name)),
+                           ValidationFailureMessage.RequiredField(nameof(Description)),
+                           ValidationFailureMessage.InvalidValue(CanonType, nameof(CanonType))
+                    )),
+                    SwaggerExample.Create($"Missing Required Field: {nameof(Name)}",
+                        new ValidationFailureResponse(
+                            ValidationFailureMessage.RequiredField(nameof(Name))
+                    )),
+                    SwaggerExample.Create("Missing Required Field: Description",
+                        new ValidationFailureResponse(
+                            ValidationFailureMessage.RequiredField(nameof(Description))
+                    )),
+                    SwaggerExample.Create("CanonType Invalid Value",
+                        "CanonType must be 1 (Canon), 2 (Legends), or 3 (Canon & Legends)",
+                        new ValidationFailureResponse(
+                            ValidationFailureMessage.InvalidValue(CanonType, nameof(CanonType))
+                    ))
+                };
+        }
+    }
+}

--- a/StarWarsTracker.Api/Program.cs
+++ b/StarWarsTracker.Api/Program.cs
@@ -1,8 +1,10 @@
+using StarWarsTracker.Api.Examples.Events;
 using StarWarsTracker.Api.Middleware;
 using StarWarsTracker.Application.Implementation;
 using StarWarsTracker.Logging;
 using StarWarsTracker.Logging.AppSettingsConfig;
 using StarWarsTracker.Persistence.Implementation;
+using Swashbuckle.AspNetCore.Filters;
 using System.Diagnostics.CodeAnalysis;
 
 [ExcludeFromCodeCoverage]
@@ -13,9 +15,35 @@ internal class Program
         var builder = WebApplication.CreateBuilder(args);
 
         builder.Services.AddControllers();
-
         builder.Services.AddEndpointsApiExplorer();
-        builder.Services.AddSwaggerGen();
+
+        builder.Services.AddSwaggerGen(c =>
+        {
+            c.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo()
+            {
+                Version = "v1",
+                Title = "Star Wars Tracker"                
+            });
+
+            c.ExampleFilters();
+            c.EnableAnnotations();
+
+            // add XML Comments for Application Assembly (Where Requests are)
+            var filePath = Path.Combine(AppContext.BaseDirectory, typeof(IRequest).Assembly.GetName().Name + ".xml");
+            if (File.Exists(filePath))
+            {
+                c.IncludeXmlComments(filePath);
+            }
+
+            // add XML Comments for API Assembly (Where Controllers are)
+            filePath = Path.Combine(AppContext.BaseDirectory, typeof(Program).Assembly.GetName().Name + ".xml");
+            if (File.Exists(filePath))
+            {
+                c.IncludeXmlComments(filePath);
+            }
+        });
+            
+        builder.Services.AddSwaggerExamplesFromAssemblyOf<Program>();
 
         // Inject Dependencies
         builder.Services.InjectPersistenceDependencies(builder.Configuration.GetConnectionString("Default"));

--- a/StarWarsTracker.Api/StarWarsTracker.Api.csproj
+++ b/StarWarsTracker.Api/StarWarsTracker.Api.csproj
@@ -5,10 +5,38 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Configurations>Debug;Release;Trace;Info;Warning;Error</Configurations>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Trace|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Info|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Warning|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Error|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/StarWarsTracker.Api/SwaggerHelpers/Attributes/AlreadyExistsExampleAttribute.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/Attributes/AlreadyExistsExampleAttribute.cs
@@ -1,0 +1,12 @@
+﻿using Swashbuckle.AspNetCore.Filters;
+using System.Net;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.Attributes
+{
+    public class AlreadyExistsExampleAttribute : SwaggerResponseExampleAttribute
+    {
+        public AlreadyExistsExampleAttribute(Type examplesProviderType) : base((int)HttpStatusCode.Conflict, examplesProviderType)
+        {
+        }
+    }
+}

--- a/StarWarsTracker.Api/SwaggerHelpers/Attributes/AlreadyExistsResponseAttribute.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/Attributes/AlreadyExistsResponseAttribute.cs
@@ -1,0 +1,15 @@
+﻿using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
+using Swashbuckle.AspNetCore.Annotations;
+using System.Net;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.Attributes
+{
+    public class AlreadyExistsResponseAttribute : SwaggerResponseAttribute
+    {
+        public const string DefaultDescription = "Conflict Response";
+
+        public AlreadyExistsResponseAttribute(string description = DefaultDescription) : base((int)HttpStatusCode.Conflict, description, typeof(AlreadyExistsResponse))
+        {
+        }
+    }
+}

--- a/StarWarsTracker.Api/SwaggerHelpers/Attributes/DoesNotExistExampleAttribute.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/Attributes/DoesNotExistExampleAttribute.cs
@@ -1,0 +1,12 @@
+﻿using Swashbuckle.AspNetCore.Filters;
+using System.Net;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.Attributes
+{
+    public class DoesNotExistExampleAttribute : SwaggerResponseExampleAttribute
+    {
+        public DoesNotExistExampleAttribute(Type examplesProviderType) : base((int)HttpStatusCode.NotFound, examplesProviderType)
+        {
+        }
+    }
+}

--- a/StarWarsTracker.Api/SwaggerHelpers/Attributes/DoesNotExistResponseAttribute.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/Attributes/DoesNotExistResponseAttribute.cs
@@ -1,0 +1,15 @@
+﻿using StarWarsTracker.Domain.Exceptions;
+using Swashbuckle.AspNetCore.Annotations;
+using System.Net;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.Attributes
+{
+    public class DoesNotExistResponseAttribute : SwaggerResponseAttribute
+    {
+        public const string DefaultDescription = "Not Found Response";
+
+        public DoesNotExistResponseAttribute(string description = DefaultDescription) : base((int)HttpStatusCode.NotFound, description, typeof(DoesNotExistResponse))
+        {
+        }
+    }
+}

--- a/StarWarsTracker.Api/SwaggerHelpers/Attributes/SuccessResponseAttribute.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/Attributes/SuccessResponseAttribute.cs
@@ -1,0 +1,17 @@
+﻿using Swashbuckle.AspNetCore.Annotations;
+using System.Net;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.Attributes
+{
+    public class SuccessResponseAttribute : SwaggerResponseAttribute
+    {
+        public const string DefaultDescription = "Success Response";
+
+        public SuccessResponseAttribute(string description = DefaultDescription) : base((int)HttpStatusCode.OK, description)
+        {
+        }
+        public SuccessResponseAttribute(Type type, string description = DefaultDescription) : base((int)HttpStatusCode.OK, description, type)
+        {
+        }
+    }
+}

--- a/StarWarsTracker.Api/SwaggerHelpers/Attributes/SuccessResponseExampleAttribute.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/Attributes/SuccessResponseExampleAttribute.cs
@@ -1,0 +1,12 @@
+﻿using Swashbuckle.AspNetCore.Filters;
+using System.Net;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.Attributes
+{
+    public class SuccessResponseExampleAttribute : SwaggerResponseExampleAttribute
+    {
+        public SuccessResponseExampleAttribute(Type examplesProviderType) : base((int)HttpStatusCode.OK, examplesProviderType)
+        {
+        }
+    }
+}

--- a/StarWarsTracker.Api/SwaggerHelpers/Attributes/ValidationFailedExampleAttribute.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/Attributes/ValidationFailedExampleAttribute.cs
@@ -1,0 +1,12 @@
+﻿using Swashbuckle.AspNetCore.Filters;
+using System.Net;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.Attributes
+{
+    public class ValidationFailedExampleAttribute : SwaggerResponseExampleAttribute
+    {
+        public ValidationFailedExampleAttribute(Type examplesProviderType) : base((int)HttpStatusCode.BadRequest, examplesProviderType)
+        {
+        }
+    }
+}

--- a/StarWarsTracker.Api/SwaggerHelpers/Attributes/ValidationFailedResponseAttribute.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/Attributes/ValidationFailedResponseAttribute.cs
@@ -1,0 +1,15 @@
+﻿using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
+using Swashbuckle.AspNetCore.Annotations;
+using System.Net;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.Attributes
+{
+    public class ValidationFailedResponseAttribute : SwaggerResponseAttribute
+    {
+        public const string DefaultDescription = "Bad Request Response";
+
+        public ValidationFailedResponseAttribute(string description = DefaultDescription) : base((int)HttpStatusCode.BadRequest, description, typeof(ValidationFailureResponse))
+        {
+        }
+    }
+}

--- a/StarWarsTracker.Api/SwaggerHelpers/ExampleProviders/IAlreadyExistExample.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/ExampleProviders/IAlreadyExistExample.cs
@@ -1,0 +1,9 @@
+﻿using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.ExampleProviders
+{
+    public interface IAlreadyExistExample : IExamplesProvider<AlreadyExistsResponse>
+    {
+    }
+}

--- a/StarWarsTracker.Api/SwaggerHelpers/ExampleProviders/IDoesNotExistExample.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/ExampleProviders/IDoesNotExistExample.cs
@@ -1,0 +1,9 @@
+﻿using StarWarsTracker.Domain.Exceptions;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.ExampleProviders
+{
+    public interface IDoesNotExistExample : IExamplesProvider<DoesNotExistResponse>
+    {
+    }
+}

--- a/StarWarsTracker.Api/SwaggerHelpers/ExampleProviders/IExample.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/ExampleProviders/IExample.cs
@@ -1,0 +1,8 @@
+﻿using Swashbuckle.AspNetCore.Filters;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.ExampleProviders
+{
+    public interface IExample<T> : IExamplesProvider<T>
+    {
+    }
+}

--- a/StarWarsTracker.Api/SwaggerHelpers/ExampleProviders/IManyExamples.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/ExampleProviders/IManyExamples.cs
@@ -1,0 +1,8 @@
+﻿using Swashbuckle.AspNetCore.Filters;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.ExampleProviders
+{
+    public interface IManyExamples<T> : IMultipleExamplesProvider<T>
+    {
+    }
+}

--- a/StarWarsTracker.Api/SwaggerHelpers/ExampleProviders/IManyValidationFailureExamples.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/ExampleProviders/IManyValidationFailureExamples.cs
@@ -1,0 +1,9 @@
+﻿using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.ExampleProviders
+{
+    public interface IManyValidationFailureExamples : IMultipleExamplesProvider<ValidationFailureResponse>
+    {
+    }
+}

--- a/StarWarsTracker.Api/SwaggerHelpers/ExampleProviders/IValidationFailureExample.cs
+++ b/StarWarsTracker.Api/SwaggerHelpers/ExampleProviders/IValidationFailureExample.cs
@@ -1,0 +1,10 @@
+﻿using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace StarWarsTracker.Api.SwaggerHelpers.ExampleProviders
+{
+    public interface IValidationFailureExample : IExamplesProvider<ValidationFailureResponse>
+    {
+
+    }
+}

--- a/StarWarsTracker.Application/BaseObjects/BaseRequests/RequiredEventGuidRequest.cs
+++ b/StarWarsTracker.Application/BaseObjects/BaseRequests/RequiredEventGuidRequest.cs
@@ -20,7 +20,11 @@ namespace StarWarsTracker.Application.BaseObjects.BaseRequests
 
         #region Public Properties
 
-        public Guid EventGuid { get; set; }
+        /// <summary>
+        /// EventGuid Required For Request
+        /// </summary>        
+        /// <example>53F5A23C-968E-4C0E-A195-79B55CD8068E</example>
+        public Guid EventGuid { get; set; } = Guid.Empty;
 
         #endregion
 

--- a/StarWarsTracker.Application/Requests/EventRequests/GetByGuid/GetEventByGuidResponse.cs
+++ b/StarWarsTracker.Application/Requests/EventRequests/GetByGuid/GetEventByGuidResponse.cs
@@ -2,6 +2,17 @@
 {
     public class GetEventByGuidResponse
     {
+        public GetEventByGuidResponse()
+        {
+            
+        }
+
+        public GetEventByGuidResponse(Event starWarsEvent, EventTimeFrame eventTimeFrame)
+        {
+            Event = starWarsEvent;
+            EventTimeFrame = eventTimeFrame;
+        }
+
         public Event Event { get; set; } = null!;
 
         public EventTimeFrame EventTimeFrame { get; set; } = null!;

--- a/StarWarsTracker.Application/Requests/EventRequests/GetByNameAndCanonType/GetEventByNameAndCanonTypeRequest.cs
+++ b/StarWarsTracker.Application/Requests/EventRequests/GetByNameAndCanonType/GetEventByNameAndCanonTypeRequest.cs
@@ -5,6 +5,8 @@ namespace StarWarsTracker.Application.Requests.EventRequests.GetByNameAndCanonTy
 {
     public class GetEventByNameAndCanonTypeRequest : IRequestResponse<GetEventByNameAndCanonTypeResponse>, IValidatable
     {
+        #region Constructors
+
         public GetEventByNameAndCanonTypeRequest() { }
 
         public GetEventByNameAndCanonTypeRequest(string name, CanonType canonType)
@@ -13,10 +15,24 @@ namespace StarWarsTracker.Application.Requests.EventRequests.GetByNameAndCanonTy
             CanonType = canonType;
         }
 
+        #endregion
+
+        #region Public Properties / Query Parameters
+
+        /// <summary>
+        /// The name of the Event to search for.
+        /// </summary>
+        /// <example>Name To Search By</example>
         public string Name { get; set; } = null!;
 
+        /// <summary>
+        /// The CanonType of the Event to search for.
+        /// Examples: Canon (1), Legends (2), or Canon And Legends (3)
+        /// </summary>
+        /// <example>1</example>
         public CanonType CanonType { get; set; }
 
+        #endregion
         public bool IsValid(out Validator validator)
         {
             validator = new(

--- a/StarWarsTracker.Application/Requests/EventRequests/GetByNameLike/GetEventsByNameLikeRequest.cs
+++ b/StarWarsTracker.Application/Requests/EventRequests/GetByNameLike/GetEventsByNameLikeRequest.cs
@@ -4,11 +4,25 @@ namespace StarWarsTracker.Application.Requests.EventRequests.GetByNameLike
 {
     public class GetEventsByNameLikeRequest : IRequestResponse<GetEventsByNameLikeResponse>, IValidatable
     {
+        #region Constructors
+
         public GetEventsByNameLikeRequest() { }
 
         public GetEventsByNameLikeRequest(string name) => Name = name;
 
+        #endregion
+
+        #region Public Property/Parameter
+
+        /// <summary>
+        /// The Name (or part of the Name) of the Event that you are searching for.
+        /// </summary>
+        /// <example>Battle</example>
         public string Name { get; set; } = string.Empty;
+
+        #endregion
+
+        #region Public IValidation Method
 
         public bool IsValid(out Validator validator)
         {
@@ -16,5 +30,7 @@ namespace StarWarsTracker.Application.Requests.EventRequests.GetByNameLike
 
             return validator.IsPassingAllRules;
         }
+
+        #endregion
     }
 }

--- a/StarWarsTracker.Application/Requests/EventRequests/GetByYear/GetEventsByYearRequest.cs
+++ b/StarWarsTracker.Application/Requests/EventRequests/GetByYear/GetEventsByYearRequest.cs
@@ -4,6 +4,11 @@
     {
         public GetEventsByYearRequest() { }
 
+        /// <summary>
+        /// The year you are looking for based on the Battle Of Yavin.
+        /// Positive Numbers are AfterBattleYavin and Negative numbers are BeforeBattleYavin.
+        /// </summary>
+        /// <example>-19</example>
         public int YearsSinceBattleOfYavin { get; set; }
     }
 }

--- a/StarWarsTracker.Application/StarWarsTracker.Application.csproj
+++ b/StarWarsTracker.Application/StarWarsTracker.Application.csproj
@@ -5,6 +5,31 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Trace;Info;Warning;Error</Configurations>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Trace|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Info|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Warning|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Error|AnyCPU'">
+    <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/StarWarsTracker.Domain/Exceptions/AlreadyExistsException.cs
+++ b/StarWarsTracker.Domain/Exceptions/AlreadyExistsException.cs
@@ -1,19 +1,28 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
+using StarWarsTracker.Domain.Constants.LogConfigs;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
 
 namespace StarWarsTracker.Domain.Exceptions
 {
     [ExcludeFromCodeCoverage]
-    public class AlreadyExistsException : Exception
+    public class AlreadyExistsException : CustomException
     {
         public AlreadyExistsException(string nameOfObjectAlreadyExisting, params (object Value, string NameOfField)[] conflicts)
         {
             NameOfObjectAlreadyExisting = nameOfObjectAlreadyExisting;
 
-            Conflicts = conflicts.Select(c => $"{nameOfObjectAlreadyExisting} already exists with {c.NameOfField}: {c.Value}");
+            Conflicts = conflicts;
         }
 
         public readonly string NameOfObjectAlreadyExisting;
 
-        public readonly IEnumerable<string> Conflicts;
+        public (object, string)[] Conflicts { get; set; }
+
+        public override int GetStatusCode() => (int)HttpStatusCode.Conflict;
+
+        public override CustomExceptionResponse GetResponseBody() => new AlreadyExistsResponse(NameOfObjectAlreadyExisting, Conflicts);
+
+        public override string GetLogLevelConfigKey() => Key.AlreadyExistsExceptionLogLevel;
     }
 }

--- a/StarWarsTracker.Domain/Exceptions/AlreadyExistsResponse.cs
+++ b/StarWarsTracker.Domain/Exceptions/AlreadyExistsResponse.cs
@@ -1,0 +1,18 @@
+﻿using StarWarsTracker.Domain.Exceptions;
+
+namespace StarWarsTracker.Application.BaseObjects.ExceptionResponses
+{
+    public class AlreadyExistsResponse : CustomExceptionResponse
+    {
+        public AlreadyExistsResponse(string nameOfObject, params (object Value, string NameOfField)[] possibleConflicts)
+        {
+            ObjectAlreadyExisting = nameOfObject;
+
+            PossibleConflicts = possibleConflicts.Any() ? possibleConflicts.Select( _ => new { Field = _.NameOfField, _.Value }) : Enumerable.Empty<object>();
+        }
+
+        public string ObjectAlreadyExisting { get; set; }
+
+        public IEnumerable<object> PossibleConflicts { get; set; }
+    }
+}

--- a/StarWarsTracker.Domain/Exceptions/CustomException.cs
+++ b/StarWarsTracker.Domain/Exceptions/CustomException.cs
@@ -1,0 +1,11 @@
+﻿namespace StarWarsTracker.Domain.Exceptions
+{
+    public abstract class CustomException : Exception
+    {
+        public abstract int GetStatusCode();
+
+        public abstract object GetResponseBody();
+
+        public abstract string GetLogLevelConfigKey();
+    }
+}

--- a/StarWarsTracker.Domain/Exceptions/CustomExceptionResponse.cs
+++ b/StarWarsTracker.Domain/Exceptions/CustomExceptionResponse.cs
@@ -1,0 +1,6 @@
+﻿namespace StarWarsTracker.Domain.Exceptions
+{
+    public abstract class CustomExceptionResponse
+    {
+    }
+}

--- a/StarWarsTracker.Domain/Exceptions/DoesNotExistException.cs
+++ b/StarWarsTracker.Domain/Exceptions/DoesNotExistException.cs
@@ -1,19 +1,27 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using StarWarsTracker.Domain.Constants.LogConfigs;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
 
 namespace StarWarsTracker.Domain.Exceptions
 {
     [ExcludeFromCodeCoverage]
-    public class DoesNotExistException : Exception
+    public class DoesNotExistException : CustomException
     {
         public DoesNotExistException(string nameOfObjectNotExisting, params(object? Value, string NameOfValue)[] valuesSearchedBy)
         {
             NameOfObjectNotExisting = nameOfObjectNotExisting;
 
-            ValuesSearchedBy = valuesSearchedBy.Select(_ => $"{_.NameOfValue} : {_.Value}");
+            ValuesSearchedBy = valuesSearchedBy;
         }
 
         public readonly string NameOfObjectNotExisting;
 
-        public readonly IEnumerable<string> ValuesSearchedBy = Enumerable.Empty<string>();
+        public readonly (object?, string)[] ValuesSearchedBy;
+
+        public override int GetStatusCode() => (int)HttpStatusCode.NotFound;
+
+        public override CustomExceptionResponse GetResponseBody() => new DoesNotExistResponse(NameOfObjectNotExisting, ValuesSearchedBy);
+
+        public override string GetLogLevelConfigKey() => Key.DoesNotExistExceptionLogLevel;
     }
 }

--- a/StarWarsTracker.Domain/Exceptions/DoesNotExistResponse.cs
+++ b/StarWarsTracker.Domain/Exceptions/DoesNotExistResponse.cs
@@ -1,0 +1,17 @@
+﻿namespace StarWarsTracker.Domain.Exceptions
+{
+    public class DoesNotExistResponse : CustomExceptionResponse
+    {
+        public DoesNotExistResponse(string nameOfObject, params (object? Value, string NameOfField)[] valuesSearchedBy)
+        {
+            NameOfObject = nameOfObject;
+            ValuesSearchedBy = valuesSearchedBy.Any() 
+                             ? valuesSearchedBy.Select(_ => new KeyValuePair<string, object?>(_.NameOfField, _.Value)) 
+                             : Enumerable.Empty<KeyValuePair<string, object?>>();
+        }
+
+        public string NameOfObject { get; set; }
+
+        public IEnumerable<KeyValuePair<string, object?>> ValuesSearchedBy { get; set; }
+    }
+}

--- a/StarWarsTracker.Domain/Exceptions/OperationFailedException.cs
+++ b/StarWarsTracker.Domain/Exceptions/OperationFailedException.cs
@@ -1,7 +1,16 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using StarWarsTracker.Domain.Constants.LogConfigs;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
 
 namespace StarWarsTracker.Domain.Exceptions
 {
     [ExcludeFromCodeCoverage]
-    public class OperationFailedException : Exception { }
+    public class OperationFailedException : CustomException
+    {
+        public override string GetLogLevelConfigKey() => Key.DefaultExceptionLogLevel;
+
+        public override CustomExceptionResponse GetResponseBody() => new OperationFailedResponse();
+
+        public override int GetStatusCode() => (int)HttpStatusCode.InternalServerError;
+    }
 }

--- a/StarWarsTracker.Domain/Exceptions/OperationFailedResponse.cs
+++ b/StarWarsTracker.Domain/Exceptions/OperationFailedResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace StarWarsTracker.Domain.Exceptions
+{
+    public class OperationFailedResponse : CustomExceptionResponse
+    {
+        public string Message { get; set; } = "Unexpected Error";
+    }
+}

--- a/StarWarsTracker.Domain/Exceptions/ValidationFailureException.cs
+++ b/StarWarsTracker.Domain/Exceptions/ValidationFailureException.cs
@@ -1,11 +1,17 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using StarWarsTracker.Application.BaseObjects.ExceptionResponses;
+using StarWarsTracker.Domain.Constants.LogConfigs;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
 
 namespace StarWarsTracker.Domain.Exceptions
 {
     [ExcludeFromCodeCoverage]
-    public class ValidationFailureException : Exception
+    public class ValidationFailureException : CustomException
     {
-        public ValidationFailureException() { }
+        public ValidationFailureException(params string[] validationFailureMessages) 
+        { 
+            ValidationFailureMessages = validationFailureMessages;
+        }
 
         public ValidationFailureException(IEnumerable<string> validationFailureMessages)
         {
@@ -13,5 +19,11 @@ namespace StarWarsTracker.Domain.Exceptions
         }
 
         public IEnumerable<string> ValidationFailureMessages { get; set; } = Enumerable.Empty<string>();
+
+        public override string GetLogLevelConfigKey() => Key.ValidationFailureExceptionLogLevel;
+
+        public override CustomExceptionResponse GetResponseBody() => new ValidationFailureResponse(ValidationFailureMessages);
+
+        public override int GetStatusCode() => (int)HttpStatusCode.BadRequest;
     }
 }

--- a/StarWarsTracker.Domain/Exceptions/ValidationFailureResponse.cs
+++ b/StarWarsTracker.Domain/Exceptions/ValidationFailureResponse.cs
@@ -1,0 +1,19 @@
+﻿using StarWarsTracker.Domain.Exceptions;
+
+namespace StarWarsTracker.Application.BaseObjects.ExceptionResponses
+{
+    public class ValidationFailureResponse : CustomExceptionResponse
+    {
+        public ValidationFailureResponse(IEnumerable<string> validationFailureReasons)
+        {
+            ValidationFailureReasons = validationFailureReasons;
+        }
+
+        public ValidationFailureResponse(params string[] validationFailureReasons)
+        {
+            ValidationFailureReasons = validationFailureReasons;
+        }
+
+        public IEnumerable<string> ValidationFailureReasons { get; set; }
+    }
+}


### PR DESCRIPTION
## StarWarsTracker.Domain Changes
Refactored Exceptions to use a CustomExceptions base class to reduce repeated code for transforming exceptions to api responses in the ExceptionHandlingMiddleware.

- Added StarWarsTracker.Domain.CustomException
- Refactored custom exceptions to inherit from CustomException and implmeent abstract methods.
- Added ExceptionResponse for each CustomException
- Refactored ExceptionHandlingMiddleware to use CustomException and remove repeated code

## StarWarsTracker.Api Changes
Added some dependencies for Swagger to enable Examples, set up some custom attributes to simplify attributes/examples providers. Set up Examples and added them to controller methods. Also added null check for handling requests.

- Added null check in base controller.
- Added StarWarsTracker.Api.SwaggerHelpers (Attributes and ExampleProviders)
- Created Examples in StarWarsTracker.Api.Examples.Events for each of the Event endpoints.
- Added attributes from StarWarsTracker.Api.SwaggerHelper to the methods in Event Controller.

## StarWarsTracker.Application Changes
Add summaries/comments that are used for Swagger Descriptions
- Added comments for Examples/Descriptions on requests that use QueryString Parameters.
   - Still need to add more comments for other objects in later PR